### PR TITLE
3.3-nginx broken after configuration changes in base image

### DIFF
--- a/3.3-nginx/docker-entrypoint.sh
+++ b/3.3-nginx/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 ENV_VARIABLES=$(awk 'BEGIN{for(v in ENVIRON) print "$"v}')
 
-for FILE in etc/nginx/nginx.conf etc/nginx/conf.d/default.conf etc/modsecurity.d/modsecurity-override.conf
+for FILE in etc/nginx/nginx.conf etc/nginx/conf.d/default.conf etc/nginx/conf.d/logging.conf etc/modsecurity.d/modsecurity-override.conf
 do
     envsubst "$ENV_VARIABLES" <$FILE | sponge $FILE
 done

--- a/3.3-nginx/nginx.conf
+++ b/3.3-nginx/nginx.conf
@@ -3,7 +3,6 @@ load_module modules/ngx_http_modsecurity_module.so;
 user ${USER};
 worker_processes 1;
 
-error_log ${ERRORLOG} ${LOGLEVEL};
 pid /var/run/nginx.pid;
 
 events {
@@ -11,18 +10,8 @@ events {
 }
 
 http {
-
-    modsecurity on;
-    modsecurity_rules_file /etc/modsecurity.d/setup.conf;
-
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
-
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log /var/log/nginx/access.log main;
 
     sendfile on;
 


### PR DESCRIPTION
After https://github.com/coreruleset/modsecurity-docker/commit/214041c580b83d38f8cb4fc2ea8e8a45eeaf9722, nginx image cannot start anymore:

```
$ docker run -p 80:80 -ti -e PROXY=1 -e LOGLEVEL=warn --rm owasp/modsecurity-crs:3.3-nginx
2020/08/07 11:28:36 [emerg] 1#1: duplicate "log_format" name "main" in /etc/nginx/conf.d/logging.conf:3
nginx: [emerg] duplicate "log_format" name "main" in /etc/nginx/conf.d/logging.conf:3
```

These changes should fix the issues.