### PR TITLE
fix(vars): use access log variable in nginx container also

### DIFF
--- a/3.3-nginx/nginx.conf
+++ b/3.3-nginx/nginx.conf
@@ -22,7 +22,7 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log /var/log/nginx/access.log main;
+    access_log ${ACCESSLOG} main;
 
     sendfile on;
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

ACCESS_LOG was only being used in apache. Let's use it also in nginx.