### PR TITLE
feat(utf8): add variable for validating utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following environment variables are available to configure the CRS container
 | UPSTREAM | The IP Address (and optional port) of the upstream server when proxy mode is enabled. (Default: the container's default router, port 81) (Examples: 192.0.2.2 or 192.0.2.2:80) |
 | EXECUTING_PARANOIA | An integer indicating the executing_paranoia_level (Default: paranoia level) |
 | ENFORCE_BODYPROC_URLENCODED | A boolean indicating the enforce_bodyproc_urlencoded (Default: 0) |
+| VALIDATE_UTF8_ENCODING | A boolean indicating the crs_validate_utf8_encoding (Default: 0) |
 | ANOMALY_INBOUND | An integer indicating the inbound_anomaly_score_threshold (Default: 5) |
 | ANOMALY_OUTBOUND | An integer indicating the outbound_anomaly_score_threshold (Default: 4) |
 | ALLOWED_METHODS | A string indicating the allowed_methods (Default: GET HEAD POST OPTIONS) |
@@ -169,6 +170,7 @@ docker run -dti 80:80 --rm \
    -e MODSEC_RESP_BODY_ACCESS=on \
    -e MODSEC_RESP_BODY_LIMIT=524288 \
    -e MODSEC_PCRE_MATCH_LIMIT=1000 \
-   -e MODSEC_PCRE_MATCH_LIMIT_RECURSION=1000
+   -e MODSEC_PCRE_MATCH_LIMIT_RECURSION=1000 \
+   -e VALIDATE_UTF8_ENCODING=1 
    owasp/modsecurity-crs
 ```

--- a/src/opt/modsecurity/activate-rules.sh
+++ b/src/opt/modsecurity/activate-rules.sh
@@ -80,3 +80,8 @@ fi
 if [ -n "$COMBINED_FILE_SIZES" ]; then
   sed -z -E -i 's/#SecAction.{6}id:900350.*tx\.combined_file_sizes=1048576\"/SecAction \\\n  \"id:900350, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.combined_file_sizes='"$COMBINED_FILE_SIZES"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
 fi
+
+# Activate UTF8 validation
+if [ -n "$VALIDATE_UTF8_ENCODING" ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900950.*tx\.crs_validate_utf8_encoding=1\"/SecAction \\\n  \"id:900950, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.crs_validate_utf8_encoding=1\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This variable is being used by the CRS testing framework (taken from the regression test docs):

Requirements
============
There are Three requirements for running the OWASP CRS regressions.

1. You must have ModSecurity specify the location of your error.log, this is done in the config.py file
2. ModSecurity must be in DetectionOnly (or anomaly scoring) mode
3. You must disable IP blocking based on previous events

Note: The test suite compares timezones -- if your test machine and your host machine are in different timezones this can cause bad results

To accomplish 2. and 3. you may use the following rule in your setup.conf:

```
SecAction "id:900005,\
  phase:1,\
  nolog,\
  pass,\
  ctl:ruleEngine=DetectionOnly,\
  ctl:ruleRemoveById=910000,\
  setvar:tx.paranoia_level=4,\
  setvar:tx.crs_validate_utf8_encoding=1,\
  setvar:tx.arg_name_length=100,\
  setvar:tx.arg_length=400"
```

So we need that variable if we want to run proper tests as the doc says.