### PR TITLE
Add tags and scheduled build

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
     - master
+    tags: 
+    - v3.3.0
+  schedule:
+  - cron: '0 12 * * MON'  # Run every Monday
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,6 +15,8 @@ jobs:
         image:
         - 3.3-apache
         - 3.3-nginx
+        tag:
+        - v3.3.0
     steps:
     - uses: actions/checkout@v1
       with:
@@ -25,11 +31,13 @@ jobs:
       run: docker build . -f ${{ matrix.image }}/Dockerfile
            --tag owasp/modsecurity-crs:${{ matrix.image }}
            --tag owasp/modsecurity-crs:$(echo ${{ matrix.image }} | sed 's/.*-//')
+           --tag owasp/modsecurity-crs:${{ matrix.tag }}
 
     - name: Set default tag for ${{ matrix.image }}
       if: endsWith(matrix.image, '-apache')
       run: docker tag owasp/modsecurity-crs:${{ matrix.image }}
                       owasp/modsecurity-crs:$(echo ${{ matrix.image }} | sed 's/-.*//')
+                      owasp/modsecurity-crs:${{ matrix.tag }}
 
     - name: Push ${{ matrix.image }}
       run: docker push owasp/modsecurity-crs

--- a/3.3-apache/Dockerfile
+++ b/3.3-apache/Dockerfile
@@ -2,8 +2,8 @@ FROM owasp/modsecurity:2
 
 LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
-ARG COMMIT=v3.3/dev
-ARG BRANCH=v3.3/dev
+ARG COMMIT=tags/v3.3.0
+ARG BRANCH=tags/v3.3.0
 ARG REPO=coreruleset/coreruleset
 
 ENV PARANOIA=1 \

--- a/3.3-nginx/Dockerfile
+++ b/3.3-nginx/Dockerfile
@@ -2,8 +2,8 @@ FROM owasp/modsecurity:3
 
 LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
-ARG COMMIT=v3.3/dev
-ARG BRANCH=v3.3/dev
+ARG COMMIT=tags/v3.3.0
+ARG BRANCH=tags/v3.3.0
 ARG REPO=coreruleset/coreruleset
 
 ENV PARANOIA=1 \


### PR DESCRIPTION
This PR adds 

- the Docker build and tag of the to be created Git tag v3.3.0.
- the scheduled weekly Docker build and push of all tags

In a next step you have to
- create the Git tag v3.3.0.
- Build the underlying modsecurity-docker image automatically 