### PR TITLE
fix(ci): fixes docker push without specific tag

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -35,4 +35,4 @@ jobs:
                       owasp/modsecurity-crs:${{ matrix.server }}
 
     - name: Push ${{ matrix.version }}-${{ matrix.server }}
-      run: docker push owasp/modsecurity-crs
+      run: docker push owasp/modsecurity-crs:${{ matrix.version }}-${{ matrix.server }} owasp/modsecurity-crs:${{ matrix.server }}


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes docker push to the hub. We are not using the tag latest, so we need to specify tags accordingly.