### PR TITLE
fix(ci): use all tags in docker push

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -35,4 +35,4 @@ jobs:
                       owasp/modsecurity-crs:${{ matrix.server }}
 
     - name: Push ${{ matrix.version }}-${{ matrix.server }}
-      run: docker push owasp/modsecurity-crs:${{ matrix.version }}-${{ matrix.server }} owasp/modsecurity-crs:${{ matrix.server }}
+      run: docker push --all-tags owasp/modsecurity-crs


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Try to use `--all-tags` instead of naming each tag.