### PR TITLE
fix(ci): update matching secrets per action documentation

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Docker Hub Description
       uses: peter-evans/dockerhub-description@v2
       with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Had to create additional secrets because dockerhub api does not support tokens yet.