### PR TITLE
fix(security): include 3.3.2 release by default

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -6,14 +6,14 @@ on:
   schedule:
     - cron: '0 12 * * MON'  # Run every Monday
 env:
-  DEFAULT_VERSION: 'v3.3.0'
+  DEFAULT_VERSION: 'v3.3.2'
   DEFAULT_SERVER: 'apache'
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['v3.3.0']
+        version: ['v3.3.2']
         server: ['apache', 'nginx']
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       # Remember to match these with the buildimage.yml action
       matrix:
-        version: ['v3.3.0']
+        version: ['v3.3.2']
         server: ['apache', 'nginx']
     steps:
     - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSIONS = v3.3.0
+VERSIONS = v3.3.2
 SERVERS = apache nginx
 TAG = owasp/modsecurity-crs
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ ModSecurity is an open source, cross platform web application firewall (WAF) eng
 Image building requires `make`, or you can do the same by calling the `src/release.sh` helper with the version release you want and the web server, e.g:
 
 ```bash
-$ ./src/release.sh "v3.3.0-apache"
-$ docker build --tag owasp/modsecurity-crs:v3.3.0-apache -f v3.3.0-apache/Dockerfile .
+$ ./src/release.sh "v3.3.2-apache"
+$ docker build --tag owasp/modsecurity-crs:v3.3.2-apache -f v3.3.2-apache/Dockerfile .
 ```
 
 If you call `make` without arguments, will build all releases and web server combinations.
 
-Or use `make VERSIONS=v3.3.0-rc1` and it will get the proper release and build the container.
+Or use `make VERSIONS=v3.3.3-rc1` and it will get the proper release and build the container.
 
 You can also add your local tag, or override the build:
 
 ```bash
-make VERSIONS=v3.3.0 SERVERS=nginx TAG=mytag
+make VERSIONS=v3.3.2 SERVERS=nginx TAG=mytag
 ```
 
 ## CRS Versions


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Updates base ruleset after security release 3.3.2.