### PR TITLE
fix(armv7): update certificates before using curl

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -38,6 +38,7 @@ RUN set -eux; \
    ca-certificates \
    curl \
    iproute2; \
+ update-ca-certificates -f; \
  mkdir /opt/owasp-crs; \
  curl -SL https://github.com/coreruleset/coreruleset/archive/v${RELEASE}.tar.gz | \
  tar -zxf - --strip-components=1 -C /opt/owasp-crs; \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This fixes curl not finding github certificates for downloading crs.