### PR TITLE
fix(apache): use SERVER_ variables from base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ docker run -dti 80:80 --rm \
    -e ERRORLOG='/proc/self/fd/2' \
    -e USER=daemon \
    -e GROUP=daemon \
-   -e SERVERADMIN=root@localhost \
-   -e SERVERNAME=localhost \
+   -e SERVER_ADMIN=root@localhost \
+   -e SERVER_NAME=localhost \
    -e PORT=80 \
    -e MODSEC_RULE_ENGINE=on \
    -e MODSEC_REQ_BODY_ACCESS=on \

--- a/apache/conf/extra/httpd-modsecurity.conf
+++ b/apache/conf/extra/httpd-modsecurity.conf
@@ -1,7 +1,6 @@
 Timeout ${TIMEOUT}
 LogLevel ${LOGLEVEL}
 ErrorLog ${ERRORLOG}
-ServerAdmin ${SERVERADMIN}
 
 <IfModule unixd_module>
   User ${USER}


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

SERVER_NAME and SERVER_ADMIN were used inconsistently in this image and the base. Fix depends on https://github.com/coreruleset/modsecurity-docker/pull/123.