### PR TITLE
Fix missing ENTRYPOINT in Apache flavor

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -49,4 +49,6 @@ COPY --from=release /opt/owasp-crs /opt/owasp-crs
 
 RUN set -eux; ln -s /opt/owasp-crs /etc/modsecurity.d/
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 # Use httpd-foreground from upstream

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -52,3 +52,4 @@ RUN set -eux; ln -s /opt/owasp-crs /etc/modsecurity.d/
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Use httpd-foreground from upstream
+CMD ["httpd-foreground"]

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -46,7 +46,9 @@ COPY apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 COPY apache/docker-entrypoint.sh /
 COPY --from=release /opt/owasp-crs /opt/owasp-crs
 
-RUN set -eux; ln -s /opt/owasp-crs /etc/modsecurity.d/
+RUN set -eux; \
+    apk add --no-cache sed; \
+    ln -s /opt/owasp-crs /etc/modsecurity.d/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -48,4 +48,6 @@ COPY --from=release /opt/owasp-crs /opt/owasp-crs
 
 RUN set -eux; ln -s /opt/owasp-crs /etc/modsecurity.d/
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 # Use httpd-foreground from upstream

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -51,3 +51,4 @@ RUN set -eux; ln -s /opt/owasp-crs /etc/modsecurity.d/
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Use httpd-foreground from upstream
+CMD ["httpd-foreground"]

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
-source /opt/modsecurity/activate-rules.sh
+. /opt/modsecurity/activate-rules.sh
 
 exec "$@"


### PR DESCRIPTION
The latest build on dockerhub of the Apache image does not have an ENTRYPOINT directive [1]. 
That leads to `activate-rules.sh` not being sourced and env variables like `ALLOWED_METHODS` not being written to `crs-setup.conf` and therefore not applied. (I noticed ALLOWED_METHOD related messages in my logs a couple of days ago)

Not sure which (parent) image set the ENTRYPOINT before. Hence I introduce it here and not in the parent image to avoid that problem in the future.

[1] https://hub.docker.com/layers/modsecurity-crs/owasp/modsecurity-crs/3.3.2-apache/images/sha256-56461eaca2a6120d10a1ec8406b76be72cdc1ce2db2ba17503f9c820cfe0912c?context=explore