### PR TITLE
feat(mode): adds MANUAL_MODE for crs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See [modsecurity-docker](https://github.com/coreruleset/modsecurity-docker/blob/
 
 | Name     | Description|
 | -------- | ------------------------------------------------------------------- |
+| MANUAL_MODE | A boolean indicating that you are providing your own `crs-setup.conf` file mounted as volume. (Default: `0`). ⚠️ None of the following variables are used if you set it to `1`. |
 | PARANOIA | An integer indicating the paranoia level (Default: `1`)               |
 | BLOCKING_PARANOIA | (:new: Replaces `PARANOIA` in CRSv4) An integer indicating the paranoia level (Default: `1`)               |
 | EXECUTING_PARANOIA | An integer indicating the executing_paranoia_level (Default: `PARANOIA`) |
@@ -107,7 +108,6 @@ See [modsecurity-docker](https://github.com/coreruleset/modsecurity-docker/blob/
 | MAX_FILE_SIZE | An integer indicating the max_file_size (Default: `unlimited`) |
 | COMBINED_FILE_SIZES | An integer indicating the combined_file_sizes (Default: `unlimited`) |
 | CRS_ENABLE_TEST_MARKER | A boolean indicating whether to write test markers to the log file (Used for running the CRS test suite. Default: `0`) |
-
 ## Notes regarding reverse proxy
 
 In order to more easily test drive the CRS ruleset, we include support for an technique called [Reverse Proxy](https://en.wikipedia.org/wiki/Reverse_proxy). Using this technique, you keep your pre-existing web server online at a non-standard host and port, and then configure the CRS container to accept public traffic. The CRS container then proxies the traffic to your pre-existing webserver. This way, you can test out CRS with any web server. Some notes:

--- a/src/opt/modsecurity/activate-rules.sh
+++ b/src/opt/modsecurity/activate-rules.sh
@@ -1,5 +1,11 @@
 #!/bin/sh -e
 
+# Check if crs-setup.conf is overriden
+if [ -n "${MANUAL_MODE}" ]; then
+  echo "Using manual config mode"
+  return; # Don't use exit on a sourced script
+fi
+
 # Paranoia Level
 sed -z -E -i 's/#SecAction.{7}id:900000.*tx\.paranoia_level=1\"/SecAction \\\n  \"id:900000, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.paranoia_level='"${PARANOIA}"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes #39.

- Adds `MANUAL_MODE` so the `crs-setup.conf` file can be mounted as a volume.