### PR TITLE
feat(ci): use unique tags when pushing to hub

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -3,49 +3,61 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 12 * * TUE" # Run every Tuesday (base run on Monday)
   repository_dispatch:
     types: [base-container-updated]
+
+env:
+  REPO: "owasp/modsecurity-crs"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crs-version:
-          - "3.3.2"
-        image:
-          - apache
-          - nginx
-        variant:
-          - ""
-          - "-alpine"
+        crs_version: ["3.3.4"]
+        image: [apache, nginx]
+        variant: ["", "-alpine"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           driver-opts: image=moby/buildkit:master
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.dockerhub_user }}
           password: ${{ secrets.dockerhub_token }}
 
-      - name: Build and push ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}
-        uses: docker/bake-action@v1.5.0
+      - name: Docker meta ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.image }}${{ matrix.variant }}
+            type=semver,pattern={{major}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{version}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+
+      - name: Build and push ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
+        uses: docker/bake-action@v2.2.0
         with:
           targets: ${{ matrix.image }}${{ matrix.variant }}
-          files: docker-bake.hcl
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
           push: true

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -5,53 +5,68 @@ on:
     branches:
       - master
       - develop
+
+env:
+  REPO: "owasp/modsecurity-crs"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crs-version:
-          - "3.3.2"
-        image:
-          - apache
-          - nginx
-        variant:
-          - ""
-          - "-alpine"
-        platform:
-          - linux/amd64
+        crs_version: ["3.3.4"]
+        image: [apache, nginx]
+        variant: ["", "-alpine"]
+        platform: [linux/amd64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           driver-opts: image=moby/buildkit:master
 
-      - name: Build ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}
-        uses: docker/bake-action@v1.5.0
+      - name: Docker meta ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          files: docker-bake.hcl
+          images: |
+            ${{ env.REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.image }}${{ matrix.variant }}
+            type=semver,pattern={{major}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{version}},value=v${{ matrix.crs_version }},suffix=${{ matrix.image }}${{ matrix.variant }}-{{date 'YYYYMMDDHHMM'}}
+
+      - name: Build ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
+        uses: docker/bake-action@v2.2.0
+        with:
           targets: ${{ matrix.image }}${{ matrix.variant }}
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
           set: |
-            "${{ matrix.image }}${{ matrix.variant }}.tags=${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}-test"
             "${{ matrix.image }}${{ matrix.variant }}.platform=${{ matrix.platform }}"
           load: true
           push: false
 
-      - name: Run ${{ matrix.image }}${{ matrix.variant }}
+      - name: Run ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
         run: |
-          docker run -d --name ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}-test ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}-test
-          docker logs ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}-test
+          TAG=$(docker image inspect -f '{{ json .RepoTags }}' ${{ env.REPO }}:${{ matrix.image }}${{ matrix.variant }} | jq -r '.[0]')
+          echo "Starting container with TAG=$TAG"
+          docker run --pull "never" -d --name ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}-test "$TAG"
+          docker logs ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}-test
 
-      - name: Verify ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}
+      - name: Verify ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}
         run: |
-          [ $(docker inspect ${{ matrix.crs-version }}-${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Running}}') = 'true' ]
+          [ $(docker inspect ${{ matrix.crs_version }}-${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Running}}') = 'true' ]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We added the [docker buildx](https://github.com/docker/buildx) support to our do
 There is a new file `docker-bake.hcl` used for this purpose. To build for new platforms, just use this example:
 
 ```bash
-$ docker buildx use $(docker buildx create --platform linux/amd64,linux/arm64,linux/arm/v8)
+$ docker buildx create --use --platform linux/amd64,linux/i386,linux/arm64,linux/arm/v7
 $ docker buildx bake -f docker-bake.hcl
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,19 @@ ModSecurity is an open source, cross platform web application firewall (WAF) eng
 
 ## Supported tags and respective `Dockerfile` links
 
-* `3-nginx`, `3.3-nginx`, `3.3.2-nginx`, `nginx` ([master/nginx/Dockerfile](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image, and latest stable Core Rule Set 3.3.2 *
-* `3-apache`, `3.3-apache`, `3.3.2-apache`, `apache` ([master/apache/Dockerfile](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile)) –*last stable ModSecurity v2 on Apache 2.4 official stable base image, and latest stable Core Rule Set 3.3.2 *
+* `3-nginx-YYYYMMDDHHMM`, `3.3-nginx-YYYYMMDDHHMM`, `3.3.2-nginx-YYYYMMDDHHMM`, `nginx` ([master/nginx/Dockerfile](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image, and latest stable Core Rule Set 3.3.2 *
+* `3-apache-YYYYMMDDHHMM`, `3.3-apache-YYYYMMDDHHMM`, `3.3.2-apache-YYYYMMDDHHMM`, `apache` ([master/apache/Dockerfile](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile)) –*last stable ModSecurity v2 on Apache 2.4 official stable base image, and latest stable Core Rule Set 3.3.2 *
+
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity-crs:nginx` or `owasp/modsecurity-crs:apache`. If you need a stable long term image, use the one with the full CRS version, in addition to the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity-crs:3.3.2-nginx-202209141209` or `owasp/modsecurity-crs:3.3.2-apache-202209141209` for example. You have been warned.
 
 ## Supported variants
 
 We have support for [alpine linux](https://www.alpinelinux.org/) variants of the base images. Just add `-alpine` and you will get it. Examples:
 
-* `3-nginx-alpine`, `3.3-nginx-alpine`, `3.3.2-nginx-alpine`, `nginx-alpine` ([master/nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 official alpine stable base image, and latest stable Core Rule Set 3.3.2 *
-* `3-apache-alpine`, `3.3-apache-alpine`, `3.3.2-apache-alpine`, `apache-alpine` ([master/apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 official alpine stable base image, and latest stable Core Rule Set 3.3.2 *
+* `3-nginx-alpine-YYYYMMDDHHMM`, `3.3-nginx-alpine-YYYYMMDDHHMM`, `3.3.2-nginx-alpine-YYYYMMDDHHMM`, `nginx-alpine` ([master/nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 official alpine stable base image, and latest stable Core Rule Set 3.3.2 *
+* `3-apache-alpine-YYYYMMDDHHMM`, `3.3-apache-alpine-YYYYMMDDHHMM`, `3.3.2-apache-alpine-YYYYMMDDHHMM`, `apache-alpine` ([master/apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 official alpine stable base image, and latest stable Core Rule Set 3.3.2 *
+
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity-crs:nginx-alpine` or `owasp/modsecurity-crs:apache-alpine`. If you need a stable long term image, use the one with the full CRS version, in addition to the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity-crs:3.3.2-nginx-alpine-202209141209` or `owasp/modsecurity-crs:3.3.2-apache-alpine-202209141209` for example. You have been warned.
 
 ## Supported architectures
 
@@ -31,21 +35,34 @@ We added the [docker buildx](https://github.com/docker/buildx) support to our do
 There is a new file `docker-bake.hcl` used for this purpose. To build for new platforms, just use this example:
 
 ```bash
-docker buildx create \
-   --name modsecurity-docker \
-   --use
-docker buildx bake -f docker-bake.hcl
+$ docker buildx use $(docker buildx create --platform linux/amd64,linux/arm64,linux/arm/v8)
+$ docker buildx bake -f docker-bake.hcl
 ```
+
+We require a version of `buildx` >= v0.9.1. [Visit the official documentation](https://docs.docker.com/build/buildx/install/) for instructions on installing and upgrading `buildx`. You can check which version you have using:
+```
+docker buildx version
+github.com/docker/buildx v0.9.1 ed00243a0ce2a0aee75311b06e32d33b44729689
+```
+
+If you want to see the targets of the build, use:
+```
+docker buildx bake -f ./docker-bake.hcl --print
+```
+
+We are building now for these architectures:
+  - linux/amd64
+  - linux/i386
+  - linux/arm64
+  - linux/arm/v7
+
+You can find additional examples on how to use `buildx` in this repository's GitHub act
+We added the [docker buildx](https://github.com/docker/buildx) support to our docker builds so additional architectures are supported now. As we create our containers based on the official apache and nginx ones, we can only support the architectures they support.
 
 To build a specific target for a single platform only (replace target and platform strings in the example with the your choices):
 
 ```bash
-docker buildx create \
-   --name modsecurity-docker \
-   --use
-docker buildx bake \
-   -f docker-bake.hcl \
-   --set target.platforms=linux/amd64 nginx-alpine
+docker buildx bake -f docker-bake.hcl --set target.platforms=linux/amd64 nginx-alpine
 ```
 
 ## CRS Versions

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:apache as release
+FROM owasp/modsecurity:2.9.6-202209170109 as release
 
 ARG RELEASE
 
@@ -23,7 +23,7 @@ RUN set -eux; \
     sed -i -E 's/(Listen) [0-9]+/\1 ${PORT}/g' /usr/local/apache2/conf/httpd.conf; \
     rm -rf /var/lib/apt/lists/*
 
-FROM owasp/modsecurity:apache
+FROM owasp/modsecurity:2.9.6-202209170109
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:apache-alpine as release
+FROM owasp/modsecurity:2.9.6-alpine-202209170109 as release
 
 ARG RELEASE
 
@@ -22,7 +22,7 @@ RUN set -eux; \
     ln -sv /opt/owasp-crs /etc/modsecurity.d/; \
     sed -i -E 's/(Listen) [0-9]+/\1 ${PORT}/g' /usr/local/apache2/conf/httpd.conf
 
-FROM owasp/modsecurity:apache-alpine
+FROM owasp/modsecurity:2.9.6-alpine-202209170109
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,24 +1,10 @@
 # docker-bake.hcl
 variable "crs-version" {
-    default = "3.3.2"
+    default = "3.3.4"
 }
 
 variable "REPO" {
     default = "owasp/modsecurity-crs"
-}
-
-function "tag" {
-    params = [tag]
-    result = ["${REPO}:${tag}"]
-}
-
-function "vtag" {
-    params = [semver, variant]
-    result = concat(
-        tag("${major(semver)}${variant}"),
-        tag("${minor(semver)}${variant}"),
-        tag("${patch(semver)}${variant}")
-    )
 }
 
 function "major" {
@@ -36,6 +22,20 @@ function "patch" {
     result = join(".", slice(split(".", version),0,3))
 }
 
+function "tag" {
+    params = [tag]
+    result = ["${REPO}:${tag}"]
+}
+
+function "vtag" {
+    params = [semver, variant]
+    result = concat(
+        tag("${major(semver)}${variant}-${formatdate("YYYYMMDDHHMM", timestamp())}"),
+        tag("${minor(semver)}${variant}-${formatdate("YYYYMMDDHHMM", timestamp())}"),
+        tag("${patch(semver)}${variant}-${formatdate("YYYYMMDDHHMM", timestamp())}")
+    )
+}
+
 group "default" {
     targets = [
         "apache",
@@ -45,7 +45,10 @@ group "default" {
     ]
 }
 
+target "docker-metadata-action" {}
+
 target "platforms-base" {
+    inherits = ["docker-metadata-action"]
     context="."    
     platforms = ["linux/amd64", "linux/arm64/v8", "linux/arm/v7", "linux/i386"]
     args = {

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:nginx as release
+FROM owasp/modsecurity:3.0.8-202209170109 as release
 
 ARG RELEASE
 
@@ -18,7 +18,7 @@ RUN set -eux; \
     rm -f v${RELEASE}.tar.gz coreruleset-${RELEASE}.tar.gz.asc; \
     mv -v /opt/owasp-crs/crs-setup.conf.example /opt/owasp-crs/crs-setup.conf
 
-FROM owasp/modsecurity:nginx
+FROM owasp/modsecurity:3.0.8-202209170109
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:nginx-alpine as release
+FROM owasp/modsecurity:3.0.8-alpine-202209170109 as release
 
 ARG RELEASE
 
@@ -18,7 +18,7 @@ RUN set -eux; \
     mv -v /opt/owasp-crs/crs-setup.conf.example /opt/owasp-crs/crs-setup.conf; \
     ln -sv /opt/owasp-crs /etc/modsecurity.d/
 
-FROM owasp/modsecurity:nginx-alpine
+FROM owasp/modsecurity:3.0.8-alpine-202209170109
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- tags are based on build date using YYYYMMDDHHMM

This is the same as https://github.com/coreruleset/modsecurity-docker/pull/140 for this repository.

Fixes #67.