### PR TITLE
Fix run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ docker start modseccrs
 ## Full docker run example of possible setup
 
 ```
-docker run -dti 80:80 --rm \
+docker run -dti -p 80:80 --rm \
    -e PARANOIA=1 \
    -e EXECUTING_PARANOIA=2 \
    -e ENFORCE_BODYPROC_URLENCODED=1 \
@@ -206,6 +206,6 @@ docker run -dti 80:80 --rm \
    -e MODSEC_PCRE_MATCH_LIMIT=1000 \
    -e MODSEC_PCRE_MATCH_LIMIT_RECURSION=1000 \
    -e VALIDATE_UTF8_ENCODING=1 \
-   -e CRS_ENABLE_TEST_MARKER=1
+   -e CRS_ENABLE_TEST_MARKER=1 \
    owasp/modsecurity-crs:apache
 ```


### PR DESCRIPTION
## Summary

I used the example code shown in README.md but it does not work. it was made by syntax errors. I fixed it.

## What I did to fix problems

- Add `-p` option to specify port instead of image
- Add `\` to connect lines

## How changed

fail -> success to run image as a container.

## Detail

When you run the command, you can see this error.

```console
Unable to find image '80:80' locally
docker: Error response from daemon: pull access denied for 80, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

This is caused by Docker recognize `80:80` as image name.

```
docker run -dti 80:80 --rm \
   -e PARANOIA=1 \
   -e EXECUTING_PARANOIA=2 \
   -e ENFORCE_BODYPROC_URLENCODED=1 \
...
```

When you fix it, next you will see this error:

```
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
```

This is caused by missing backslash:

```
docker run -dti -p 80:80 --rm \
   -e PARANOIA=1 \
   -e EXECUTING_PARANOIA=2 \
...
   -e MODSEC_PCRE_MATCH_LIMIT_RECURSION=1000 \
   -e VALIDATE_UTF8_ENCODING=1 \
   -e CRS_ENABLE_TEST_MARKER=1 # HERE, missing backslash
   owasp/modsecurity-crs:3.3.4-nginx-202209221209
```

So, I added it and then I can run the image as a container.
