### PR TITLE
Use current modsecurity base image in apache Dockerfile

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity:2.9.6-202209170109 as release
+FROM owasp/modsecurity:2.9.6-202210230310 as release
 
 ARG RELEASE
 
@@ -23,7 +23,7 @@ RUN set -eux; \
     sed -i -E 's/(Listen) [0-9]+/\1 ${PORT}/g' /usr/local/apache2/conf/httpd.conf; \
     rm -rf /var/lib/apt/lists/*
 
-FROM owasp/modsecurity:2.9.6-202209170109
+FROM owasp/modsecurity:2.9.6-202210230310
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 


### PR DESCRIPTION
Use current modsecurity base image, to enable environment variable `PROXY_ERROR_OVERRIDE` from the [latest release](https://github.com/coreruleset/modsecurity-docker/pull/162)