### PR TITLE
feat(plugins): move activation to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ All these variables impact in configuration directives in the modsecurity engine
 | Name     | Description|
 | -------- | ------------------------------------------------------------------- |
 | MANUAL_MODE | A boolean indicating that you are providing your own `crs-setup.conf` file mounted as volume. (Default: `0`). ⚠️ None of the following variables are used if you set it to `1`. |
+| CRS_DISABLE_PLUGINS | A boolean indicating whether plugins will be **disabled** (Only from v4 and up. Default: `0`) |
 | PARANOIA | An integer indicating the paranoia level (Default: `1`)               |
 | BLOCKING_PARANOIA | (:new: Replaces `PARANOIA` in CRSv4) An integer indicating the paranoia level (Default: `1`)               |
 | EXECUTING_PARANOIA | An integer indicating the executing_paranoia_level (Default: `PARANOIA`) |

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -153,7 +153,7 @@ COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
-COPY src/opt/modsecurity/activate-rules.sh /opt/modsecurity/
+COPY src/opt/modsecurity/activate-*.sh /opt/modsecurity/
 COPY apache/docker-entrypoint.sh /
 
 RUN set -eux; \

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -161,7 +161,7 @@ COPY --from=build /usr/share/TLS/server.crt                                    /
 COPY --from=crs_release /opt/owasp-crs /opt/owasp-crs
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY src/bin/healthcheck /usr/local/bin/healthcheck
-COPY src/opt/modsecurity/activate-rules.sh /opt/modsecurity/
+COPY src/opt/modsecurity/activate-*.sh /opt/modsecurity/
 COPY apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 COPY apache/docker-entrypoint.sh /
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 
+. /opt/modsecurity/activate-plugins.sh
 . /opt/modsecurity/activate-rules.sh
 
 exec "$@"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -183,6 +183,7 @@ COPY --from=crs_release /opt/owasp-crs /opt/owasp-crs
 COPY src/etc/modsecurity.d/modsecurity-override.conf /etc/nginx/templates/modsecurity.d/modsecurity-override.conf.template
 COPY src/etc/modsecurity.d/setup.conf /etc/nginx/templates/modsecurity.d/setup.conf.template
 COPY nginx/docker-entrypoint.d/*.sh /docker-entrypoint.d/
+COPY src/opt/modsecurity/activate-plugins.sh /docker-entrypoint.d/94-activate-plugins.sh
 COPY src/opt/modsecurity/activate-rules.sh /docker-entrypoint.d/95-activate-rules.sh
 # We use the templating mechanism from the nginx image here,
 # as set up by owasp/modsecurity-docker

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -180,6 +180,7 @@ COPY src/etc/modsecurity.d/modsecurity-override.conf /etc/nginx/templates/modsec
 COPY src/etc/modsecurity.d/setup.conf /etc/nginx/templates/modsecurity.d/setup.conf.template
 COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY nginx/docker-entrypoint.d/*.sh /docker-entrypoint.d/
+COPY src/opt/modsecurity/activate-plugins.sh /docker-entrypoint.d/94-activate-plugins.sh
 COPY src/opt/modsecurity/activate-rules.sh /docker-entrypoint.d/95-activate-rules.sh
 
 

--- a/src/opt/modsecurity/activate-plugins.sh
+++ b/src/opt/modsecurity/activate-plugins.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+# Check if crs-setup.conf is overriden
+if [ -n "${MANUAL_MODE}" ]; then
+  echo "Using manual config mode"
+  return; # Don't use exit on a sourced script
+fi
+
+# Plugins can be disabled entirely by setting CRS_DISABLE_PLUGINS.
+if [ -n "${CRS_DISABLE_PLUGINS}" ]; then
+    echo "Plugins will be disabled"
+    return; # Don't use exit on a sourced script
+fi
+
+# Handle plugins if we have the files.
+# Note: we are careful here to not assume the existance of the "plugins"
+# directory. It is being introduced with version 4 of CRS.
+for suffix in "config" "before" "after"; do
+    if [ -n "$(find /opt/owasp-crs -path "/opt/owasp-crs/plugins/*-${suffix}.conf")" ]; then
+        # enable if there are config files
+        sed -i -E "s/^#\s*(.+-${suffix}\.conf)/\1/" /etc/modsecurity.d/setup.conf
+    else
+        # disable if there are no config files
+        sed -i -E "s/^([^#]+-${suffix}\.conf)/# \1/" /etc/modsecurity.d/setup.conf
+    fi
+done
+

--- a/src/opt/modsecurity/activate-rules.sh
+++ b/src/opt/modsecurity/activate-rules.sh
@@ -139,15 +139,3 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \\
 EOF
 fi
 
-# Handle plugins if we have the files.
-# Note: we are careful here to not assume the existance of the "plugins"
-# directory. It is being introduced with version 4 of CRS.
-for suffix in "config" "before" "after"; do
-    if [ -n "$(find /opt/owasp-crs -path "/opt/owasp-crs/plugins/*-${suffix}.conf")" ]; then
-        # enable if there are config files
-        sed -i -E "s/^#\s*(.+-${suffix}\.conf)/\1/" /etc/modsecurity.d/setup.conf
-    else
-        # disable if there are no config files
-        sed -i -E "s/^([^#]+-${suffix}\.conf)/# \1/" /etc/modsecurity.d/setup.conf
-    fi
-done


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- moves plugin activation to its own activation file
- adds a new variable to completely disable plugins, even if files are present