### PR TITLE
Use libpcre3 instead of libpcre++ to reduce build time and image size.

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -5,7 +5,7 @@ FROM nginx:${NGINX_VERSION} as build
 ARG MODSEC_VERSION=3.0.8 \
     LMDB_VERSION=0.9.29
 
-# Note: libpcre++-dev (PCRE3) is required by the build description,
+# Note: libpcre3-dev (PCRE) is required by the build description,
 # even though the build will use PCRE2.
 RUN set -eux; \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
@@ -20,7 +20,7 @@ RUN set -eux; \
         libfuzzy-dev \
         libgeoip-dev \
         liblua5.3-dev \
-        libpcre++-dev \
+        libpcre3-dev \
         libpcre2-dev \
         libtool \
         libxml2-dev \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -4,7 +4,7 @@ FROM nginx:${NGINX_VERSION}-alpine as build
 
 ARG MODSEC_VERSION=3.0.8
 
-# Note: pcre-dev (PCRE3) is required by the build description,
+# Note: pcre-dev (PCRE) is required by the build description,
 # even though the build will use PCRE2.
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
ModSecurity depends on libpcre3-dev. libpcre++-dev also depends on libpcre3-dev.
So we can just use libpcre3-dev to avoid redundancy.