### PR TITLE
Fix crs version docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can achieve the same results just by getting any version you want, and using
 git clone https://github.com/coreruleset/coreruleset.git myrules
 cd myrules
 git checkout ac2a0d1
-docker run -p 80:80 -ti -e PARANOIA=4 -v ./rules:/opt/owasp-crs/rules:ro --rm owasp/modsecurity-crs
+docker run -p 80:80 -ti -e PARANOIA=4 -v rules:/opt/owasp-crs/rules:ro --rm owasp/modsecurity-crs
 ```
 
 ## Quick reference


### PR DESCRIPTION
This PR is going to fix the CRS docker command as https://github.com/coreruleset/modsecurity-crs-docker#crs-versions

```sh
❯ docker run -p 80:80 -ti -e PARANOIA=4 -v ./rules:/opt/owasp-crs/rules:ro --rm owasp/modsecurity-crs
docker: Error response from daemon: create ./rules: "./rules" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

Works well in my macOS 13.2 with Docker desktop version 4.16.2 (95914)

```sh
docker run -p 80:80 -ti -e PARANOIA=4 -v rules:/opt/owasp-crs/rules:ro --rm owasp/modsecurity-crs
```