### PR TITLE
fix: prevent healthcheck from triggering rules

### DIFF
--- a/src/bin/healthcheck
+++ b/src/bin/healthcheck
@@ -13,4 +13,4 @@ then
     port="${PORT}"
 fi
 
-curl -sk "${scheme}://${host}:${port}/healthz"
+curl -sk -A healthcheck "${scheme}://${host}:${port}/healthz"


### PR DESCRIPTION
The default curl user agent triggers CRS. The healthcheck now uses a custom user agent to prevent this.