### PR TITLE
docs: default value of SSL_ENGINE is `on`

### DIFF
--- a/README-containers.md
+++ b/README-containers.md
@@ -103,7 +103,7 @@ These variables are common to image variants and will set defaults based on the 
 | SERVER_ADMIN | Address where problems with the server should be e-mailed (Default: `root@localhost`) |
 | SERVER_NAME | Server name (Default: `localhost`) |
 | SSL_CIPHER_SUITE | Cipher suite to use. Uses OpenSSL [list of cipher suites](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html) (Default: `"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"` |
-| SSL_ENGINE | The SSL Engine Operation Switch (Default: `off`) |
+| SSL_ENGINE | The SSL Engine Operation Switch (Default: `on`) |
 | SSL_HONOR_CIPHER_ORDER | if the server should [honor the cipher list provided by the client](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslhonorcipherorder) (Allowed values: `on`, `off`. Default: `off`) |
 | SSL_PROTOCOL | A string for configuring the [usable SSL/TLS protocol versions](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslprotocol) (Default: `"all -SSLv3 -TLSv1 -TLSv1.1"`) |
 | SSL_PROXY_PROTOCOL | A string for configuring the [proxy client SSL/TLS protocol versions](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslproxyprotocol) (Default: `"all -SSLv3 -TLSv1 -TLSv1.1"`) |


### PR DESCRIPTION
The default value of SSL_ENGINE was never correct in the Docker Hub readme.