### PR TITLE
feat: add server_tokens to nginx images

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ docker run -p 8080:80 -e SERVER_NAME=myhost my-modsec
 | SERVER_ADMIN  | A string value indicating the address where problems with the server should be e-mailed (Default: `root@localhost`) |
 | SERVER_NAME | A string value indicating the server name (Default: `localhost`) |
 | SERVER_SIGNATURE | A string value configuring the footer on server-generated documents (Default: `Off`) |
-| SERVER_TOKENS | A string value configuring the Server HTTP response header. Also see MODSEC_SERVER_SIGNATURE. (Default: `Full`). |
+| SERVER_TOKENS | A string value indicating the server header of HTTP responses. Also see MODSEC_SERVER_SIGNATURE. (Default: `Full`). |
 | SSL_CIPHER_SUITE | A string indicating the cipher suite to use. Uses OpenSSL [list of cipher suites](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html) (Default: `"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"` |
 | SSL_ENGINE  | A string indicating the SSL Engine Operation Switch (Default: `on`) |
 | SSL_HONOR_CIPHER_ORDER | A string indicating if the server should [honor the cipher list provided by the client](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslhonorcipherorder) (Allowed values: `on`, `off`. Default: `off`) |
@@ -213,6 +213,7 @@ Note: Apache access and metric logs can be disabled by exporting the `nologging=
 | PROXY_SSL_PROTOCOLS | A string value indicating the ssl protocols to enable (default: `TTLSv1.2 TLSv1.3`)|
 | PROXY_SSL_VERIFY  | A string value indicating if the client certificates should be verified (Allowed values: `on`, `off`. Default: `off`) |
 | PROXY_TIMEOUT  | Number of seconds for proxied requests to time out connections (Default: `60s`) |
+| SERVER_TOKENS | A string value indicating the server header of HTTP responses and the version number in the footer on error pages. (Allowed values: `on`, `off`. Default: `off`). |
 | SSL_PORT  | Port number where the SSL enabled webserver is listening (Default: `443`) |
 | TIMEOUT  | Number of seconds for a keep-alive client connection to stay open on the server side (Default: `60s`) |
 | WORKER_CONNECTIONS  | Maximum number of simultaneous connections that can be opened by a worker process (Default: `1024`) |

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -152,6 +152,7 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     PROXY_SSL_VERIFY=off \
     PROXY_SSL_OCSP_STAPLING=off \
     SERVER_NAME=localhost \
+    SERVER_TOKENS=off \
     SSL_PORT=443 \
     TIMEOUT=60s \
     WORKER_CONNECTIONS=1024 \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -146,6 +146,7 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     PROXY_SSL_VERIFY=off \
     PROXY_SSL_OCSP_STAPLING=off \
     SERVER_NAME=localhost \
+    SERVER_TOKENS=off \
     SSL_PORT=443 \
     TIMEOUT=60s \
     WORKER_CONNECTIONS=1024 \

--- a/nginx/templates/conf.d/server_tokens.conf.template
+++ b/nginx/templates/conf.d/server_tokens.conf.template
@@ -1,0 +1,1 @@
+server_tokens ${SERVER_TOKENS};


### PR DESCRIPTION
This PR adds the nginx directive `server_tokens` to our nginx images and solves part 2 of issue #143.

Full plan:
https://github.com/coreruleset/modsecurity-crs-docker/pull/151#issuecomment-1705366720