### PR TITLE
fix: lua compilation

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
         libtool \
         libxml2-dev \
         libyajl-dev \
-        lua5.2-dev \
+        lua5.3-dev \
         make \
         pkgconf \
         wget
@@ -161,6 +161,7 @@ RUN set -eux; \
         iproute2 \
         libcurl3-gnutls \
         libfuzzy2 \
+        liblua5.3 \
         libxml2 \
         libyajl2; \
     update-ca-certificates -f; \

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -27,8 +27,8 @@ RUN set -eux; \
     libtool \
     lmdb-dev \
     libxml2-dev \
+    lua5.3-dev \
     yajl-dev \
-    lua-dev \
     make \
     openssl \
     openssl-dev \
@@ -166,6 +166,7 @@ RUN set -eux; \
         iproute2 \
         libfuzzy2 \
         libxml2 \
+        lua5.3 \
         moreutils \
         openssl \
         sed \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -25,6 +25,7 @@ RUN set -eux; \
         libxml2-dev \
         linux-headers \
         lmdb-dev \
+        lua5.3-dev \
         make \
         openssl \
         openssl-dev \
@@ -185,6 +186,7 @@ RUN set -eux; \
         libstdc++ \
         libxml2-dev \
         lmdb-dev \
+        lua5.3 \
         moreutils \
         openssl \
         tzdata \


### PR DESCRIPTION
- update Lua to 5.3 (the highest supported version)
- add missing Lua packages (httpd comes with Lua 5.2 installed, but if we want 5.3 we need to include that package in the final image)

Fixes #176