### PR TITLE
feat: drop support for overriding USER

### DIFF
--- a/README-containers.md
+++ b/README-containers.md
@@ -174,8 +174,6 @@ All these variables impact in configuration directives in the modsecurity engine
 
 | Name | Description|
 | -- | -- |
-| USER | Name (or #number) of the user to run httpd or nginx as (Default: `www-data` (httpd), `nginx` (nginx)) |
-| GROUP | Name (or #number) of the group to run httpd as (Default: `www-data`) |
 | BACKEND | Backend address (and optional port) of the backend server. (Default: the container's default router, port 81) (Examples: 192.0.2.2, 192.0.2.2:80, <http://172.17.0.1:8000>) |
 
 ### CRS specific

--- a/README.md
+++ b/README.md
@@ -259,8 +259,6 @@ All these variables impact in configuration directives in the modsecurity engine
 
 | Name     | Description|
 | -------- | ------------------------------------------------------------------- |
-| USER | A string value indicating the name (or #number) of the user to run httpd or nginx as (Default: `www-data` (httpd), `nginx` (nginx)) |
-| GROUP | A string value indicating the name (or #number) of the group to run httpd as (Default: `www-data`) |
 | BACKEND  | The backend address (and optional port) of the backend server. (Default: the container's default router, port 81) (Examples: 192.0.2.2, 192.0.2.2:80, <http://172.17.0.1:8000>) |
 
 ### CRS specific
@@ -359,8 +357,6 @@ docker run -dti -p 80:80 --rm \
    -e TIMEOUT=60 \
    -e LOGLEVEL=warn \
    -e ERRORLOG='/proc/self/fd/2' \
-   -e USER=daemon \
-   -e GROUP=daemon \
    -e SERVER_ADMIN=root@localhost \
    -e SERVER_NAME=localhost \
    -e PORT=80 \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -134,8 +134,6 @@ ENV APACHE_ALWAYS_TLS_REDIRECT=off \
     SSL_USE_STAPLING=On \
     TIMEOUT=60 \
     WORKER_CONNECTIONS=400 \
-    USER=www-data \
-    GROUP=www-data \
     # CRS specific variables
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -144,9 +144,6 @@ ENV APACHE_ALWAYS_TLS_REDIRECT=off \
     SSL_USE_STAPLING=On \
     TIMEOUT=60 \
     WORKER_CONNECTIONS=400 \
-    # overridden variables
-    USER=www-data \
-    GROUP=www-data \
     # CRS specific variables
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \

--- a/apache/conf/extra/httpd-modsecurity.conf
+++ b/apache/conf/extra/httpd-modsecurity.conf
@@ -7,11 +7,6 @@ ErrorLog ${ERRORLOG}
 # https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#secserversignature
 SecServerSignature ${MODSEC_SERVER_SIGNATURE}
 
-<IfModule unixd_module>
-  User ${USER}
-  Group ${GROUP}
-</IfModule>
-
 <IfModule reqtimeout_module>
   RequestReadTimeout header=20-40,MinRate=500 body=20,MinRate=500
 </IfModule>

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -160,8 +160,6 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     WORKER_CONNECTIONS=1024 \
     LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib \
     NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
-    # overridden variables
-    USER=nginx \
     # CRS specific variables
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -155,8 +155,6 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     WORKER_CONNECTIONS=1024 \
     LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib \
     NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
-    # overridden variables
-    USER=nginx \
     # CRS specific variables
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \


### PR DESCRIPTION
Overrideing the USER only makes sense if it can be configured at build time, as that user needs to exist on the system. For containers, this functionality doesn't make much sense anyway.

Fixes #184