### PR TITLE
chore: error if port or ssl_port are lower than 1024

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -2,6 +2,20 @@
 
 /usr/local/bin/generate-certificate /usr/local/apache2
 
+if [ "${PORT}" -lt 1024 ] || [ "${SSL_PORT}" -lt 1024 ]; then
+  echo "ERROR: you are using PORT=${PORT} and SSL_PORT=${SSL_PORT}"
+  echo "Both nginx and httpd containers now run with an unprivileged user. This means that we cannot bind to ports below 1024, so you might need to correct your PORT and SSL_PORT settings. Now the defaults for both nginx and httpd are 8080 and 8443."
+  echo "FIX:"
+  echo "if you have a port mapping like"
+  echo "ports:"
+  echo " - \"80:80\""
+  echo "then update it to use a port higher than 1024. Example:"
+  echo " - \"80:8080\""
+  echo "The same should be done for the SSL ports."
+    
+  exit 1
+fi
+
 . /opt/modsecurity/activate-plugins.sh
 . /opt/modsecurity/activate-rules.sh
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,20 +1,7 @@
 #!/bin/sh -e
 
 /usr/local/bin/generate-certificate /usr/local/apache2
-
-if [ "${PORT}" -lt 1024 ] || [ "${SSL_PORT}" -lt 1024 ]; then
-  echo "ERROR: you are using PORT=${PORT} and SSL_PORT=${SSL_PORT}"
-  echo "Both nginx and httpd containers now run with an unprivileged user. This means that we cannot bind to ports below 1024, so you might need to correct your PORT and SSL_PORT settings. Now the defaults for both nginx and httpd are 8080 and 8443."
-  echo "FIX:"
-  echo "if you have a port mapping like"
-  echo "ports:"
-  echo " - \"80:80\""
-  echo "then update it to use a port higher than 1024. Example:"
-  echo " - \"80:8080\""
-  echo "The same should be done for the SSL ports."
-    
-  exit 1
-fi
+/usr/local/bin/check-low-port
 
 . /opt/modsecurity/activate-plugins.sh
 . /opt/modsecurity/activate-rules.sh

--- a/nginx/docker-entrypoint.d/01-check-low-port.sh
+++ b/nginx/docker-entrypoint.d/01-check-low-port.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+/usr/local/bin/check-low-port
+
+exit 0

--- a/src/bin/check-low-port
+++ b/src/bin/check-low-port
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ "${PORT}" -lt 1024 ] || [ "${SSL_PORT}" -lt 1024 ]; then
+  echo<<EOF
+ERROR: you are using PORT=${PORT} and SSL_PORT=${SSL_PORT}
+
+Both nginx and httpd containers now run with an unprivileged user.
+
+This means that we cannot bind to ports below 1024, so you might need to correct your PORT and SSL_PORT settings.
+Now the defaults for both nginx and httpd are 8080 and 8443.
+
+FIX:
+
+if you have a port mapping like
+
+ports:
+- "80:80"
+
+then update it to use a port higher than 1024. Example:
+
+- "80:8080"
+
+The same should be done for the SSL ports.
+EOF
+  exit 1
+fi


### PR DESCRIPTION
## what

- do not start container if port or ssl_port are defined lower than 1024

## why

after moving to unprivileged containers, people might not have updated their setups, bringing problems when starting