### PR TITLE
chore: create a new release when we... release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Build and publish images for container registries
+
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   prepare:


### PR DESCRIPTION
We are using the two branch approach when we can just stick to one main branch and just release new versions.

This should simplify generating new releases, and keep commits cleaner.