### PR TITLE
Fix heredoc in check-low-port

### DIFF
--- a/src/bin/check-low-port
+++ b/src/bin/check-low-port
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "${PORT}" -lt 1024 ] || [ "${SSL_PORT}" -lt 1024 ]; then
-  echo<<EOF
+  cat<<EOF
 ERROR: you are using PORT=${PORT} and SSL_PORT=${SSL_PORT}
 
 Both nginx and httpd containers now run with an unprivileged user.


### PR DESCRIPTION
The container did not start anymore on the latest build. The logs didn't really tell what was going on, because the message from the check-low-port script is not printed. Heredoc needs to go through `cat`, not `echo`.