### PR TITLE
fix: split restricted headers to work with crs 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ All these variables impact in configuration directives in the modsecurity engine
 | MAX_NUM_ARGS | An integer indicating the max_num_args (Default: `unlimited`) |
 | PARANOIA | An integer indicating the paranoia level (Default: `1`)               |
 | RESTRICTED_EXTENSIONS | A string indicating the restricted_extensions (Default: `.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/`) |
-| RESTRICTED_HEADERS | A string indicating the restricted_headers (Default: `/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/`) |
+| RESTRICTED_HEADERS_BASIC | A string indicating the restricted_headers_basic (Default: `/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/`) |
+| RESTRICTED_HEADERS_EXTENDED | A string indicating the restricted_headers_extended (Default: `/accept-charset/`) |
 | STATIC_EXTENSIONS | A string indicating the static_extensions (Default: `/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/`) |
 | TOTAL_ARG_LENGTH | An integer indicating the total_arg_length (Default: `unlimited`) |
 | VALIDATE_UTF8_ENCODING | A boolean indicating the crs_validate_utf8_encoding (Default: `0`) |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,8 @@ x-defaults: &default-settings
     # ALLOWED_REQUEST_CONTENT_TYPE_CHARSET: 'utf-8|iso-8859-1|iso-8859-15|windows-1252'
     # ALLOWED_HTTP_VERSIONS: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
     # RESTRICTED_EXTENSIONS: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
-    # RESTRICTED_HEADERS: /accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/
+    # RESTRICTED_HEADERS_BASIC: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
+    # RESTRICTED_HEADERS_EXTENDED: /accept-charset/
     # STATIC_EXTENSIONS: /.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/
 
     #######################################################

--- a/src/opt/modsecurity/activate-rules.sh
+++ b/src/opt/modsecurity/activate-rules.sh
@@ -59,9 +59,14 @@ if [ -n "${RESTRICTED_EXTENSIONS}" ]; then
   sed -z -E -i 's|#SecAction[^"]+"id:900240.*\x27tx\.restricted_extensions=[[:lower:][:space:]./]*\/\x27\"|SecAction \\\n  \"id:900240, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_extensions='"${RESTRICTED_EXTENSIONS}"'\x27\"|' "${setup_conf_path}"
 fi
 
-# Forbidden request headers.
-if [ -n "${RESTRICTED_HEADERS}" ]; then
-  sed -z -E -i 's|#SecAction[^"]+"id:900250.*\x27tx\.restricted_headers=[[:lower:][:space:]/-]*\x27\"|SecAction \\\n  \"id:900250, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_headers='"${RESTRICTED_HEADERS}"'\x27\"|' "${setup_conf_path}"
+# Forbidden request headers basic.
+if [ -n "${RESTRICTED_HEADERS_BASIC}" ]; then
+  sed -z -E -i 's|#SecAction[^"]+"id:900250.*\x27tx\.restricted_headers_basic=[[:lower:][:space:]/-]*\x27\"|SecAction \\\n  \"id:900250, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_headers_basic='"${RESTRICTED_HEADERS_BASIC}"'\x27\"|' "${setup_conf_path}"
+fi
+
+# Forbidden request headers extended.
+if [ -n "${RESTRICTED_HEADERS_EXTENDED}" ]; then
+  sed -z -E -i 's|#SecAction[^"]+"id:900255.*\x27tx\.restricted_headers_extended=[[:lower:][:space:]/-]*\x27\"|SecAction \\\n  \"id:900255, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_headers_extended='"${RESTRICTED_HEADERS_EXTENDED}"'\x27\"|' "${setup_conf_path}"
 fi
 
 # File extensions considered static files.


### PR DESCRIPTION
Adresses issue: https://github.com/coreruleset/modsecurity-crs-docker/issues/256