### PR TITLE
fix: use correct branch for tests

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -3,9 +3,7 @@ name: Verify Images
 on:
   pull_request:
     branches:
-      - master
-      - develop
-
+      - main
 env:
   REPO: "owasp/modsecurity-crs"
   # sha256sum format: <hash><space><format (space for text)><file name>


### PR DESCRIPTION
We didn't move the branches when renaming.