### PR TITLE
Fix permissions on /tmp/modsecurity directory on Apache image

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -186,7 +186,6 @@ RUN set -eux; \
     mkdir -p /tmp/modsecurity/data; \
     mkdir -p /tmp/modsecurity/upload; \
     mkdir -p /tmp/modsecurity/tmp; \
-    chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity; \
     mkdir -p /var/log/apache2/; \
     ln -s /opt/owasp-crs /etc/modsecurity.d/; \
     sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf; \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -216,6 +216,7 @@ RUN set -eux; \
         /var/log/ \
         /usr/local/apache2/ \
         /etc/modsecurity.d \
+        /tmp/modsecurity \
         /opt/owasp-crs
 
 USER httpd

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -220,6 +220,7 @@ RUN set -eux; \
         /var/log/ \
         /usr/local/apache2/ \
         /etc/modsecurity.d \
+        /tmp/modsecurity \
         /opt/owasp-crs
 
 USER httpd

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -215,7 +215,6 @@ RUN set -eux; \
     mkdir -p /tmp/modsecurity/data; \
     mkdir -p /tmp/modsecurity/upload; \
     mkdir -p /tmp/modsecurity/tmp; \
-    chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity /var/log/apache2; \
     chown -R httpd:httpd \
         /var/log/ \
         /usr/local/apache2/ \


### PR DESCRIPTION
Following #227, http user cannot read or write /tmp/modsecurity. Added /tmp/modsecurity to the list of directories owned by httpd.

This fixes #262 