### PR TITLE
chore: run renovate daily to quickly catch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>coreruleset/renovate-config",
-    "schedule:weekly"
+    "schedule:daily"
   ],
   "enabledManagers": [
     "custom.regex"


### PR DESCRIPTION
## what

- run renovate daily

## why

- catch updates faster on CRS, upstream changes and more.