### PR TITLE
fix: use MODSEC_ARGUMENTS_LIMIT in SecRule for argument count limit

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -7,7 +7,7 @@ on:
 env:
   REPO: "owasp/modsecurity-crs"
   # sha256sum format: <hash><space><format (space for text)><file name>
-  MODSECURITY_RECOMMENDED: "284b0ab56e5f13cba6a804f73dd05646b6f0a6c1a342f69838eca220344d76e5  modsecurity.conf-recommended"
+  MODSECURITY_RECOMMENDED: "ccff8ba1f12428b34ff41960d8bf773dd9f62b9a7c77755247a027cb01896d4f  modsecurity.conf-recommended"
 
 jobs:
   prepare:

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -7,7 +7,7 @@ on:
 env:
   REPO: "owasp/modsecurity-crs"
   # sha256sum format: <hash><space><format (space for text)><file name>
-  MODSECURITY_RECOMMENDED: "ccff8ba1f12428b34ff41960d8bf773dd9f62b9a7c77755247a027cb01896d4f  modsecurity.conf-recommended"
+  MODSECURITY_RECOMMENDED: "284b0ab56e5f13cba6a804f73dd05646b6f0a6c1a342f69838eca220344d76e5  modsecurity.conf-recommended"
 
 jobs:
   prepare:

--- a/src/etc/modsecurity.d/modsecurity.conf
+++ b/src/etc/modsecurity.d/modsecurity.conf
@@ -43,7 +43,7 @@ SecRule REQUEST_HEADERS:Content-Type "^(?:application(?:/soap\+|/)|text/)xml" \
     "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
 SecRule REQUEST_HEADERS:Content-Type "^application/json" \
     "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
-SecRule &ARGS "@ge 1000" \
+SecRule &ARGS "@ge ${MODSEC_ARGUMENTS_LIMIT}" \
     "id:'200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
 SecRule REQBODY_ERROR "!@eq 0" \
     "id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"


### PR DESCRIPTION
### Description

This update replaces the fixed value `1000` in the `SecRule` with the `${MODSEC_ARGUMENTS_LIMIT}` variable within the `src/etc/modsecurity.d/modsecurity.conf` file.

### Why?

- **Centralized Configuration**: Utilizing `${MODSEC_ARGUMENTS_LIMIT}` centralizes the configuration of the argument limit, simplifying future adjustments and ensuring consistency across the configuration files.
  
- **Alignment with Documentation**: According to the [ModSecurity Reference Manual](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29#secargumentslimit), it's recommended to pair the `SecArgumentsLimit` directive with a corresponding rule. This prevents attackers from bypassing the limit by adding additional parameters beyond the set threshold.

### Changes

- **Modified File**: `src/etc/modsecurity.d/modsecurity.conf`
- **Changes Made**:
  - **Before:**
    ```apache
    SecRule &ARGS "@ge 1000" \
        "id:'200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
    ```
  - **After:**
    ```apache
    SecRule &ARGS "@ge ${MODSEC_ARGUMENTS_LIMIT}" \
        "id:'200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
    ```

---

Thank you for considering this contribution! Please let me know if any adjustments are needed.

