### PR TITLE
Fix /tmp/modsecurity/* directories permissions so nginx workers can write to them

### DIFF
--- a/openresty/Dockerfile-alpine
+++ b/openresty/Dockerfile-alpine
@@ -236,8 +236,9 @@ RUN set -eux; \
     mkdir /var/log/nginx; \
     mkdir -p /tmp/modsecurity/data; \
     mkdir -p /tmp/modsecurity/upload; \
-    mkdir -p /tmp/modsecurity/tmp; \ 
+    mkdir -p /tmp/modsecurity/tmp; \
     mkdir -p /usr/local/modsecurity; \
+    chown -R nobody:nobody /tmp/modsecurity; \
     # Comment out the SecDisableBackendCompression option since it is not supported in V3
     sed -i 's/^\(SecDisableBackendCompression .*\)/# \1/' /usr/local/openresty/nginx/templates/modsecurity.d/modsecurity-override.conf.template; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC3_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so.3.0; \


### PR DESCRIPTION
Hello,

We've noticed these errors in the logs:

```
[173049359014.027868] [/private/api/v1/fileUpload] [1] Multipart: Failed to create file: /tmp/modsecurity/upload/20241101-203950-173049359014.027868-file-XXXXXX
[173049359014.027868] [/private/api/v1/fileUpload] [1] Multipart: Final boundary missing.
```

The important bit is `Multipart: Failed to create file`, while `Multipart: Final boundary missing` is the consequence of that and is not the cause, but the effect of the issue.

This PR changes the ownership on /tmp/modsecurity from root:root to nobody:nobody recursively, so nginx workers running under that user can write to the directories within /tmp/modsecurity.