### PR TITLE
fix: deactivate use of missing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,14 @@ These variables are common to image variants and will set defaults based on the 
 
 ### Nginx ENV Variables
 
-| Name     | Description|
-| -------- | ------------------------------------------------------------------- |
-| CORS_HEADER_403_ALLOW_ORIGIN | The value of the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header for `403` responses. Determines which origins can access the response. (Default: `"*"`). |
+<!-- temporarily hidden -->
+<!-- | CORS_HEADER_403_ALLOW_ORIGIN | The value of the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header for `403` responses. Determines which origins can access the response. (Default: `"*"`). |
 | CORS_HEADER_403_ALLOW_METHODS | The value of the [Access-Control-Request-Method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method) header for `403` responses. Determines the allowed request methods for the resource. Default: `"GET, POST, PUT, DELETE, OPTIONS"` |
 | CORS_HEADER_403_CONTENT_TYPE | The value of the  `Content-Type` header for `403` responses. Default: (`"text/plain"`) |
-| CORS_HEADER_403_MAX_AGE | The value of the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) header for `403` responses. The number of seconds that preflight requests for this resource may be cached by the browser. (Default: `3600`) |
+| CORS_HEADER_403_MAX_AGE | The value of the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) header for `403` responses. The number of seconds that preflight requests for this resource may be cached by the browser. (Default: `3600`) | -->
+
+| Name     | Description|
+| -------- | ------------------------------------------------------------------- |
 | DNS_SERVER  | A string indicating the name servers used to resolve names of upstream servers into addresses. For localhost backend this value should not be defined (Default: _not defined_) |
 | KEEPALIVE_TIMEOUT  | Number of seconds for a keep-alive client connection to stay open on the server side (Default: `60s`) |
 | NGINX_ALWAYS_TLS_REDIRECT | A string value indicating if http should redirect to https (Allowed values: `on`, `off`. Default: `off`) |

--- a/nginx/templates/conf.d/default.conf.template
+++ b/nginx/templates/conf.d/default.conf.template
@@ -62,7 +62,8 @@ server {
     location / {
         client_max_body_size 0;
 
-        include includes/cors.conf;
+        # temporarily disabled, since the upstream image doesn't include the required module
+        # include includes/cors.conf;
         include includes/proxy_backend.conf;
 
         index index.html index.htm;

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,6 +1,7 @@
 load_module modules/ngx_http_modsecurity_module.so;
 # allows to add cors headers when replying with 403
-load_module modules/ngx_http_headers_more_filter_module.so;
+# temporarily disabled, since the upstream image doesn't include the module
+# load_module modules/ngx_http_headers_more_filter_module.so;
 
 worker_processes auto;
 pid /tmp/nginx.pid;


### PR DESCRIPTION
The ngx_http_headers_more_filter_module isn't shipped in the upstream image, which currently breaks our images when nginx tries to load the module at startup.

Fixes #306