### PR TITLE
docs: fix default value for ALLOWED_REQUEST_CONTENT_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ All these variables impact in configuration directives in the modsecurity engine
 | ALLOWED_HTTP_VERSIONS | A string indicating the allowed_http_versions (Default: `HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0`) |
 | ALLOWED_METHODS | A string indicating the allowed_methods (Default: `GET HEAD POST OPTIONS`) |
 | ALLOWED_REQUEST_CONTENT_TYPE | A string indicating the allowed_request_content_type (Default: `\|application/x-www-form-urlencoded\| \|multipart/form-data\| \|multipart/related\| \|text/xml\| \|application/xml\| \|application/soap+xml\| \|application/json\| \|application/cloudevents+json\| \|application/cloudevents-batch+json\|`) |
-| ALLOWED_REQUEST_CONTENT_TYPE_CHARSET | A string indicating the allowed_request_content_type_charset (Default: `utf-8\|iso-8859-1\|iso-8859-15\|windows-1252`) |
+| ALLOWED_REQUEST_CONTENT_TYPE_CHARSET | A string indicating the allowed_request_content_type_charset (Default: `\|utf-8\| \|iso-8859-1\| \|iso-8859-15\| \|windows-1252\|`) |
 | ANOMALY_INBOUND | An integer indicating the inbound_anomaly_score_threshold (Default: `5`) |
 | ANOMALY_OUTBOUND | An integer indicating the outbound_anomaly_score_threshold (Default: `4`) |
 | ARG_LENGTH | An integer indicating the arg_length (Default: `unlimited`) |


### PR DESCRIPTION
The default value for ALLOWED_REQUEST_CONTENT_TYPE shown in README.md doesn't match the actual default value in CRS, which is misleading if you try to customize the setting by following the example. This PR corrects that.