### PR TITLE
fix: replace `$upstream` variable with `BACKEND` env var

### DIFF
--- a/nginx/templates/conf.d/default.conf.template
+++ b/nginx/templates/conf.d/default.conf.template
@@ -11,7 +11,6 @@ server {
     listen ${PORT} default_server;
 
     server_name ${SERVER_NAME};
-    set $upstream ${BACKEND};
     set $always_redirect ${NGINX_ALWAYS_TLS_REDIRECT};
 
     PROXY_SSL_CONFIG
@@ -38,7 +37,6 @@ server {
     listen ${SSL_PORT} ssl;
 
     server_name ${SERVER_NAME};
-    set $upstream ${BACKEND};
 
     ssl_certificate ${SSL_CERT};
     ssl_certificate_key ${SSL_CERT_KEY};

--- a/nginx/templates/includes/proxy_backend.conf.template
+++ b/nginx/templates/includes/proxy_backend.conf.template
@@ -14,7 +14,7 @@ proxy_read_timeout 36000s;
 proxy_redirect off;
 
 proxy_pass_header Authorization;
-proxy_pass $upstream;
+proxy_pass ${BACKEND};
 
 SET_REAL_IP_FROM
 real_ip_header ${REAL_IP_HEADER};


### PR DESCRIPTION
`proxy_pass` will use the resolver whenever the argument contains variables. This isn't usually an issue but it can be if hosts are declared via `/etc/hosts`, e.g. when useing `extra_hosts` from docker compose. Then, `/etc/hosts` would not be considered.

Use the `BACKEND` variable directly to avoid use of the resolver.

Fixes #330