### PR TITLE
fix: Add allowedVersions to restrict Nginx to stable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Examples:
 
 ## OS Variants
 
-* nginx – *latest stable ModSecurity v3 on Nginx 1.26.2 official stable base image, and latest stable OWASP CRS 4.11.0*
+* nginx – *latest stable ModSecurity v3 on Nginx 1.26.3 official stable base image, and latest stable OWASP CRS 4.11.0*
    * [nginx](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)
    * [nginx-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine)
 * Apache httpd – *last stable ModSecurity v2 on Apache 2.4.63 official stable base image, and latest stable OWASP CRS 4.11.0*

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Examples:
 
 ## OS Variants
 
-* nginx – *latest stable ModSecurity v3 on Nginx 1.27.3 official stable base image, and latest stable OWASP CRS 4.11.0*
+* nginx – *latest stable ModSecurity v3 on Nginx 1.26.2 official stable base image, and latest stable OWASP CRS 4.11.0*
    * [nginx](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)
    * [nginx-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine)
 * Apache httpd – *last stable ModSecurity v2 on Apache 2.4.63 official stable base image, and latest stable OWASP CRS 4.11.0*

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,7 +16,7 @@ variable "crs-version" {
 
 variable "nginx-version" {
     # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
-    default = "1.26.2"
+    default = "1.26.3"
 }
 
 variable "httpd-version" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,7 +16,7 @@ variable "crs-version" {
 
 variable "nginx-version" {
     # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
-    default = "1.27.3"
+    default = "1.26.2"
 }
 
 variable "httpd-version" {

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,12 @@
         "ModSecurity2"
       ],
       "allowedVersions": "/^v2.*/"
+    },
+    {
+      "matchDepNames": [
+        "nginxinc/nginx-unprivileged"
+      ],
+      "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]\\.[0-9]+$/"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -53,7 +53,7 @@
       "matchDepNames": [
         "nginxinc/nginx-unprivileged"
       ],
-      "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]\\.[0-9]+$/"
+      "allowedVersions": "/^[0-9]+\\.(?:[1-9]\\d*)?[02468]\\.[0-9]+$/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
closes: #336 

### Background
Nginx’s stable branch is recommended for production, but Renovate is currently tracking the mainline (1.27.x) releases. 
We need to restrict updates to stable versions to follow best practices and ensure reliability.

### Changes
Updated `renovate.json` to add `allowedVersions` using a regex that matches only stable (even minor) versions of `nginxinc/nginx-unprivileged`.
This ensures Renovate will not propose mainline updates (e.g., 1.27.x).

### Testing
Ran a local dry-run (`LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset --dry-run`) and confirmed that only stable patch updates (e.g., 1.26.3) are picked up.

```
❯ node -v
v22.13.1

❯ npx renovate --version
39.176.4

# Escaping for local dry-run
❯ gsed -z -i 's/    "local>coreruleset\/renovate-config",\n//g' renovate.json   

❯ LOG_LEVEL=debug npx renovate --platform=local --repository-cache=reset --dry-run
```

<details>
<summary>Dry Run Outputs</summary>

```
DEBUG: Using RE2 regex engine
DEBUG: Parsing configs
DEBUG: Checking for config file in config.js
DEBUG: No config file found on disk - skipping
 WARN: cli config dryRun property has been changed to full
DEBUG: File config
       "config": {}
DEBUG: CLI config
       "config": {"repositoryCache": "reset", "dryRun": "full", "platform": "local"}
DEBUG: Env config
       "config": {"hostRules": []}
DEBUG: Combined config
       "config": {
         "hostRules": [],
         "repositoryCache": "reset",
         "dryRun": "full",
         "platform": "local"
       }
DEBUG: Enabling forkProcessing while in non-autodiscover mode
DEBUG: Enabling onboardingNoDeps while in non-autodiscover mode
DEBUG: Found valid git version: 2.48.1
DEBUG: Setting global hostRules
DEBUG: Using baseDir: /var/folders/29/dyr9xpb51h93r6kcr_v01x4r0000gn/T/renovate
DEBUG: Using cacheDir: /var/folders/29/dyr9xpb51h93r6kcr_v01x4r0000gn/T/renovate/cache
DEBUG: Using containerbaseDir: /var/folders/29/dyr9xpb51h93r6kcr_v01x4r0000gn/T/renovate/cache/containerbase
DEBUG: Initializing Renovate internal cache into /var/folders/29/dyr9xpb51h93r6kcr_v01x4r0000gn/T/renovate/cache/renovate/renovate-cache-v1
DEBUG: Commits limit = null
DEBUG: Setting global hostRules
DEBUG: validatePresets()
DEBUG: Reinitializing hostRules for repo
DEBUG: Clearing hostRules
 INFO: Repository started (repository=local)
       "renovateVersion": "39.176.4"
DEBUG: Using localDir: /Users/pc221203/workspace/modsecurity-crs-docker (repository=local)
DEBUG: PackageFiles.clear() - Package files deleted (repository=local)
DEBUG: Resetting npmrc (repository=local)
DEBUG: Resetting npmrc (repository=local)
DEBUG: checkOnboarding() (repository=local)
DEBUG: isOnboarded() (repository=local)
DEBUG: findFile(renovate.json) (repository=local)
DEBUG: Got file list using git (repository=local)
DEBUG: Config file exists, fileName: renovate.json (repository=local)
DEBUG: Repo is onboarded (repository=local)
DEBUG: Got file list using git (repository=local)
DEBUG: Found renovate.json config file (repository=local)
DEBUG: Repository config (repository=local)
       "fileName": "renovate.json",
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["schedule:daily"],
         "enabledManagers": ["custom.regex"],
         "packageRules": [
           {
             "groupName": "all non-major dependencies",
             "groupSlug": "all-minor-patch",
             "matchUpdateTypes": ["minor", "patch"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {
             "groupName": "all major dependencies",
             "groupSlug": "all-major",
             "matchUpdateTypes": ["major"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {"matchDepNames": ["ModSecurity2"], "allowedVersions": "/^v2.*/"},
           {
             "matchDepNames": ["nginxinc/nginx-unprivileged"],
             "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]\\.[0-9]+$/"
           }
         ],
         "customManagers": [
           {
             "description": "Bake file",
             "customType": "regex",
             "fileMatch": ["^docker-bake\\.hcl$"],
             "matchStrings": [
               "depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?\\s+datasource=(?<datasource>[^\\s]+)\\s+[^\"]+\"(?<currentValue>[^\"]+)\""
             ]
           },
           {
             "description": "Docs: nginx",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on [Nn]ginx (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "nginxinc/nginx-unprivileged",
             "datasourceTemplate": "docker"
           },
           {
             "description": "Docs: httpd",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on Apache (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "httpd",
             "datasourceTemplate": "docker"
           },
           {
             "description": "Docs: CRS",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": ["OWASP CRS (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "coreruleset/coreruleset",
             "datasourceTemplate": "github-releases"
           }
         ]
       }
DEBUG: migrateAndValidate() (repository=local)
DEBUG: No config migration necessary (repository=local)
DEBUG: Post-massage config (repository=local)
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["schedule:daily"],
         "enabledManagers": ["custom.regex"],
         "packageRules": [
           {
             "groupName": "all non-major dependencies",
             "groupSlug": "all-minor-patch",
             "matchUpdateTypes": ["minor", "patch"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {
             "groupName": "all major dependencies",
             "groupSlug": "all-major",
             "matchUpdateTypes": ["major"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {"matchDepNames": ["ModSecurity2"], "allowedVersions": "/^v2.*/"},
           {
             "matchDepNames": ["nginxinc/nginx-unprivileged"],
             "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]\\.[0-9]+$/"
           }
         ],
         "customManagers": [
           {
             "description": ["Bake file"],
             "customType": "regex",
             "fileMatch": ["^docker-bake\\.hcl$"],
             "matchStrings": [
               "depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?\\s+datasource=(?<datasource>[^\\s]+)\\s+[^\"]+\"(?<currentValue>[^\"]+)\""
             ]
           },
           {
             "description": ["Docs: nginx"],
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on [Nn]ginx (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "nginxinc/nginx-unprivileged",
             "datasourceTemplate": "docker"
           },
           {
             "description": ["Docs: httpd"],
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on Apache (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "httpd",
             "datasourceTemplate": "docker"
           },
           {
             "description": ["Docs: CRS"],
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": ["OWASP CRS (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "coreruleset/coreruleset",
             "datasourceTemplate": "github-releases"
           }
         ]
       }
DEBUG: Found repo ignorePaths (repository=local)
       "ignorePaths": ["**/node_modules/**", "**/bower_components/**"]
DEBUG: No vulnerability alerts found (repository=local)
DEBUG: No baseBranches (repository=local)
DEBUG: extract() (repository=local)
DEBUG: Got file list using git (repository=local)
DEBUG: Using file match: ^docker-bake\.hcl$ for manager regex (repository=local)
DEBUG: Using file match: ^README\.md$ for manager regex (repository=local)
DEBUG: Using file match: ^README\.md$ for manager regex (repository=local)
DEBUG: Using file match: ^README\.md$ for manager regex (repository=local)
DEBUG: Matched 1 file(s) for manager regex: docker-bake.hcl (repository=local)
DEBUG: Matched 1 file(s) for manager regex: README.md (repository=local)
DEBUG: Matched 1 file(s) for manager regex: README.md (repository=local)
DEBUG: Matched 1 file(s) for manager regex: README.md (repository=local)
DEBUG: manager extract durations (ms) (repository=local)
       "managers": {"regex": 14}
DEBUG: Found regex package files (repository=local)
DEBUG: Found regex package files (repository=local)
DEBUG: Found regex package files (repository=local)
DEBUG: Found regex package files (repository=local)
DEBUG: Found 4 package file(s) (repository=local)
 INFO: Dependency extraction complete (repository=local)
       "stats": {
         "managers": {"regex": {"fileCount": 4, "depCount": 9}},
         "total": {"fileCount": 4, "depCount": 9}
       }
 WARN: GitHub token is required for some dependencies (repository=local)
       "githubDeps": ["ModSecurity3", "ModSecurity2", "coreruleset/coreruleset"]
DEBUG: hostRules: no authentication for hub.docker.com (repository=local)
DEBUG: Using queue: host=hub.docker.com, concurrency=16 (repository=local)
DEBUG: PackageFiles.add() - Package file saved for base branch (repository=local)
DEBUG: Package releases lookups complete (repository=local)
DEBUG: Repository libYears (repository=local)
       "managerLibYears": {"regex": 0.0767693014332826},
       "totalLibYears": 0.0767693014332826,
       "totalDepsCount": 5,
       "outdatedDepsCount": 1
DEBUG: branchifyUpgrades (repository=local)
DEBUG: detectSemanticCommits() (repository=local)
DEBUG: getCommitMessages (repository=local)
DEBUG: semanticCommits: detected "unknown" (repository=local)
DEBUG: semanticCommits: disabled (repository=local)
DEBUG: 2 flattened updates found: nginxinc/nginx-unprivileged, nginxinc/nginx-unprivileged (repository=local)
DEBUG: Returning 1 branch(es) (repository=local)
DEBUG: config.repoIsOnboarded=true (repository=local)
DEBUG: packageFiles with updates (repository=local)
       "config": {
         "regex": [
           {
             "deps": [
               {
                 "depName": "ModSecurity3",
                 "packageName": "owasp-modsecurity/ModSecurity",
                 "currentValue": "3.0.13",
                 "datasource": "github-releases",
                 "replaceString": "depName=ModSecurity3 packageName=owasp-modsecurity/ModSecurity datasource=github-releases\n    default = \"3.0.13\"",
                 "skipReason": "github-token-required",
                 "updates": []
               },
               {
                 "depName": "ModSecurity2",
                 "packageName": "owasp-modsecurity/ModSecurity",
                 "currentValue": "2.9.8",
                 "datasource": "github-releases",
                 "replaceString": "depName=ModSecurity2 packageName=owasp-modsecurity/ModSecurity datasource=github-releases\n    default = \"2.9.8\"",
                 "skipReason": "github-token-required",
                 "updates": []
               },
               {
                 "depName": "coreruleset/coreruleset",
                 "currentValue": "4.11.0",
                 "datasource": "github-releases",
                 "replaceString": "depName=coreruleset/coreruleset datasource=github-releases\n    default = \"4.11.0\"",
                 "skipReason": "github-token-required",
                 "updates": [],
                 "packageName": "coreruleset/coreruleset"
               },
               {
                 "depName": "nginxinc/nginx-unprivileged",
                 "currentValue": "1.26.2",
                 "datasource": "docker",
                 "replaceString": "depName=nginxinc/nginx-unprivileged datasource=docker\n    default = \"1.26.2\"",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "1.26.3",
                     "newValue": "1.26.3",
                     "releaseTimestamp": "2025-02-17T03:20:31.633Z",
                     "newVersionAgeInDays": 4,
                     "newMajor": 1,
                     "newMinor": 26,
                     "newPatch": 3,
                     "updateType": "patch",
                     "libYears": 0.0767693014332826,
                     "branchName": "renovate/all-minor-patch"
                   }
                 ],
                 "packageName": "nginxinc/nginx-unprivileged",
                 "versioning": "docker",
                 "warnings": [],
                 "sourceUrl": "https://github.com/nginxinc/docker-nginx-unprivileged",
                 "registryUrl": "https://index.docker.io",
                 "currentVersion": "1.26.2",
                 "currentVersionTimestamp": "2025-01-20T02:50:34.943Z",
                 "currentVersionAgeInDays": 32,
                 "isSingleVersion": true,
                 "fixedVersion": "1.26.2"
               },
               {
                 "depName": "httpd",
                 "currentValue": "2.4.63",
                 "datasource": "docker",
                 "replaceString": "depName=httpd datasource=docker\n    default = \"2.4.63\"",
                 "updates": [],
                 "packageName": "httpd",
                 "versioning": "docker",
                 "warnings": [],
                 "registryUrl": "https://index.docker.io",
                 "lookupName": "library/httpd",
                 "currentVersion": "2.4.63",
                 "currentVersionTimestamp": "2025-02-04T06:52:47.537Z",
                 "currentVersionAgeInDays": 16,
                 "fixedVersion": "2.4.63"
               }
             ],
             "matchStrings": [
               "depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?\\s+datasource=(?<datasource>[^\\s]+)\\s+[^\"]+\"(?<currentValue>[^\"]+)\""
             ],
             "packageFile": "docker-bake.hcl"
           },
           {
             "deps": [
               {
                 "depName": "nginxinc/nginx-unprivileged",
                 "currentValue": "1.26.2",
                 "datasource": "docker",
                 "replaceString": "* nginx – *latest stable ModSecurity v3 on Nginx 1.26.2",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "1.26.3",
                     "newValue": "1.26.3",
                     "releaseTimestamp": "2025-02-17T03:20:31.633Z",
                     "newVersionAgeInDays": 4,
                     "newMajor": 1,
                     "newMinor": 26,
                     "newPatch": 3,
                     "updateType": "patch",
                     "libYears": 0.0767693014332826,
                     "branchName": "renovate/all-minor-patch"
                   }
                 ],
                 "packageName": "nginxinc/nginx-unprivileged",
                 "versioning": "docker",
                 "warnings": [],
                 "sourceUrl": "https://github.com/nginxinc/docker-nginx-unprivileged",
                 "registryUrl": "https://index.docker.io",
                 "currentVersion": "1.26.2",
                 "currentVersionTimestamp": "2025-01-20T02:50:34.943Z",
                 "currentVersionAgeInDays": 32,
                 "isSingleVersion": true,
                 "fixedVersion": "1.26.2"
               }
             ],
             "matchStrings": [".*on [Nn]ginx (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "nginxinc/nginx-unprivileged",
             "datasourceTemplate": "docker",
             "packageFile": "README.md"
           },
           {
             "deps": [
               {
                 "depName": "httpd",
                 "currentValue": "2.4.63",
                 "datasource": "docker",
                 "replaceString": "* Apache httpd – *last stable ModSecurity v2 on Apache 2.4.63",
                 "updates": [],
                 "packageName": "httpd",
                 "versioning": "docker",
                 "warnings": [],
                 "registryUrl": "https://index.docker.io",
                 "lookupName": "library/httpd",
                 "currentVersion": "2.4.63",
                 "currentVersionTimestamp": "2025-02-04T06:52:47.537Z",
                 "currentVersionAgeInDays": 16,
                 "fixedVersion": "2.4.63"
               }
             ],
             "matchStrings": [".*on Apache (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "httpd",
             "datasourceTemplate": "docker",
             "packageFile": "README.md"
           },
           {
             "deps": [
               {
                 "depName": "coreruleset/coreruleset",
                 "currentValue": "4.11.0",
                 "datasource": "github-releases",
                 "replaceString": "OWASP CRS 4.11.0",
                 "skipReason": "github-token-required",
                 "updates": [],
                 "packageName": "coreruleset/coreruleset"
               },
               {
                 "depName": "coreruleset/coreruleset",
                 "currentValue": "4.11.0",
                 "datasource": "github-releases",
                 "replaceString": "OWASP CRS 4.11.0",
                 "skipReason": "github-token-required",
                 "updates": [],
                 "packageName": "coreruleset/coreruleset"
               }
             ],
             "matchStrings": ["OWASP CRS (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "coreruleset/coreruleset",
             "datasourceTemplate": "github-releases",
             "packageFile": "README.md"
           }
         ]
       }
DEBUG: detectSemanticCommits() (repository=local)
DEBUG: semanticCommits: returning "disabled" from cache (repository=local)
DEBUG: processRepo() (repository=local)
DEBUG: Processing 1 branch: renovate/all-minor-patch (repository=local)
DEBUG: 0 PRs are currently open (repository=local)
DEBUG: ConcurrentPRs count = 0 (repository=local)
DEBUG: 1 already existing branches found. (repository=local)
DEBUG: Branches count = 1 (repository=local)
DEBUG: Calculating PRs created so far in this hour currentHourStart=2025-02-21T06:00:00.000Z (repository=local)
DEBUG: 0 PRs have been created so far in this hour. (repository=local)
DEBUG: HourlyPRs count = 0 (repository=local)
DEBUG: syncBranchState() (repository=local, branch=renovate/all-minor-patch)
DEBUG: syncBranchState(): Branch cache not found, creating minimal branchState (repository=local, branch=renovate/all-minor-patch)
DEBUG: branchExists=true (repository=local, branch=renovate/all-minor-patch)
DEBUG: dependencyDashboardCheck=undefined (repository=local, branch=renovate/all-minor-patch)
DEBUG: Check for closed PR because recreating closed PRs is disabled. (repository=local, branch=renovate/all-minor-patch)
DEBUG: prAlreadyExisted=false (repository=local, branch=renovate/all-minor-patch)
DEBUG: Open PR Count: 0, Existing Branch Count: 1, Hourly PR Count: 0 (repository=local, branch=renovate/all-minor-patch)
DEBUG: Checking if PR has been edited (repository=local, branch=renovate/all-minor-patch)
DEBUG: Checking schedule(schedule=* 0-3 * * *, tz=null, now=2025-02-21T06:11:44.282Z) (repository=local, branch=renovate/all-minor-patch)
DEBUG: Checking 1 schedule(s) (repository=local, branch=renovate/all-minor-patch)
DEBUG: Human-readable summary for cron:: Every minute, between 12:00 AM and 03:59 AM (repository=local, branch=renovate/all-minor-patch)
DEBUG: Package not scheduled (repository=local, branch=renovate/all-minor-patch)
DEBUG: Skipping PR creation out of schedule (repository=local, branch=renovate/all-minor-patch)
DEBUG: Existing config file no longer exists (repository=local)
DEBUG: Got file list using git (repository=local)
DEBUG: Found renovate.json config file (repository=local)
DEBUG: Repository config (repository=local)
       "fileName": "renovate.json",
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["schedule:daily"],
         "enabledManagers": ["custom.regex"],
         "packageRules": [
           {
             "groupName": "all non-major dependencies",
             "groupSlug": "all-minor-patch",
             "matchUpdateTypes": ["minor", "patch"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {
             "groupName": "all major dependencies",
             "groupSlug": "all-major",
             "matchUpdateTypes": ["major"],
             "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending"],
             "matchPackageNames": ["*"]
           },
           {"matchDepNames": ["ModSecurity2"], "allowedVersions": "/^v2.*/"},
           {
             "matchDepNames": ["nginxinc/nginx-unprivileged"],
             "allowedVersions": "/^[0-9]+\\.[0-9]*[02468]\\.[0-9]+$/"
           }
         ],
         "customManagers": [
           {
             "description": "Bake file",
             "customType": "regex",
             "fileMatch": ["^docker-bake\\.hcl$"],
             "matchStrings": [
               "depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?\\s+datasource=(?<datasource>[^\\s]+)\\s+[^\"]+\"(?<currentValue>[^\"]+)\""
             ]
           },
           {
             "description": "Docs: nginx",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on [Nn]ginx (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "nginxinc/nginx-unprivileged",
             "datasourceTemplate": "docker"
           },
           {
             "description": "Docs: httpd",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": [".*on Apache (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "httpd",
             "datasourceTemplate": "docker"
           },
           {
             "description": "Docs: CRS",
             "customType": "regex",
             "fileMatch": ["^README\\.md$"],
             "matchStrings": ["OWASP CRS (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
             "depNameTemplate": "coreruleset/coreruleset",
             "datasourceTemplate": "github-releases"
           }
         ]
       }
DEBUG: Config does not need migration (repository=local)
DEBUG: ensureDependencyDashboard() (repository=local)
 INFO: DRY-RUN: Would close Dependency Dashboard (repository=local)
       "title": "Dependency Dashboard"
DEBUG: checkReconfigureBranch() (repository=local)
DEBUG: Not attempting to reconfigure when running with local platform (repository=local)
 INFO: DRY-RUN: Would save repository cache. (repository=local)
DEBUG: Removing any stale branches (repository=local)
DEBUG: config.repoIsOnboarded=true (repository=local)
DEBUG: No renovate branches found (repository=local)
DEBUG: PackageFiles.clear() - Package files deleted (repository=local)
DEBUG: Branch summary (repository=local)
       "cacheModified": undefined,
       "baseBranches": [{"branchName": "", "sha": null}],
       "branches": [],
       "defaultBranch": "",
       "inactiveBranches": ["renovate/all-minor-patch"]
DEBUG: branches info extended (repository=local)
       "branchesInformation": [
         {
           "branchName": "renovate/all-minor-patch",
           "prNo": null,
           "prTitle": "Update nginxinc/nginx-unprivileged Docker tag to v1.26.3",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "docker",
               "depName": "nginxinc/nginx-unprivileged",
               "displayPending": "",
               "fixedVersion": "1.26.2",
               "currentVersion": "1.26.2",
               "currentValue": "1.26.2",
               "newValue": "1.26.3",
               "newVersion": "1.26.3",
               "packageFile": "README.md",
               "updateType": "patch",
               "packageName": "nginxinc/nginx-unprivileged"
             },
             {
               "datasource": "docker",
               "depName": "nginxinc/nginx-unprivileged",
               "displayPending": "",
               "fixedVersion": "1.26.2",
               "currentVersion": "1.26.2",
               "currentValue": "1.26.2",
               "newValue": "1.26.3",
               "newVersion": "1.26.3",
               "packageFile": "docker-bake.hcl",
               "updateType": "patch",
               "packageName": "nginxinc/nginx-unprivileged"
             }
           ]
         }
       ]
DEBUG: Renovate repository PR statistics (repository=local)
       "stats": {"total": 0, "open": 0, "closed": 0, "merged": 0}
DEBUG: Repository result: done, status: onboarded, enabled: true, onboarded: true (repository=local)
DEBUG: repository problems (repository=local)
       "repoProblems": ["WARN: GitHub token is required for some dependencies"]
DEBUG: Repository timing splits (milliseconds) (repository=local)
       "splits": {"init": 85, "extract": 31, "lookup": 1988, "onboarding": 0, "update": 13},
       "total": 2145
DEBUG: Package cache statistics (repository=local)
       "get": {"count": 8, "avgMs": 14, "medianMs": 15, "maxMs": 34, "totalMs": 109},
       "set": {"count": 4, "avgMs": 9, "medianMs": 7, "maxMs": 16, "totalMs": 34}
DEBUG: HTTP statistics (repository=local)
       "hosts": {
         "hub.docker.com": {
           "count": 2,
           "reqAvgMs": 1504,
           "reqMedianMs": 1830,
           "reqMaxMs": 1830,
           "queueAvgMs": 1,
           "queueMedianMs": 1,
           "queueMaxMs": 1
         }
       },
       "requests": 2
DEBUG: HTTP cache statistics (repository=local)
DEBUG: Lookup statistics (repository=local)
       "docker": {"count": 4, "avgMs": 1813, "medianMs": 1963, "maxMs": 1964, "totalMs": 7252}
 INFO: Repository finished (repository=local)
       "cloned": undefined,
       "durationMs": 2145
DEBUG: Checking file package cache for expired items
DEBUG: Deleted 0 of 8 file cached entries in 45ms
```

</details>

Please let me know if there’s anything else you'd like me to adjust!