### PR TITLE
Allow IPv6 resolver for nginx

### DIFF
--- a/nginx/docker-entrypoint.d/91-update-resolver.sh
+++ b/nginx/docker-entrypoint.d/91-update-resolver.sh
@@ -8,4 +8,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 DNS_SERVER="${DNS_SERVER:-$(grep -i '^nameserver' /etc/resolv.conf | head -n1 | cut -d ' ' -f2)}"
 
+if echo "$DNS_SERVER" | grep -q ':'; then
+    DNS_SERVER="[${DNS_SERVER}]"
+fi
+
 sed -i.bak -r 's/DNS_SERVER/'"${DNS_SERVER}"'/' /etc/nginx/nginx.conf


### PR DESCRIPTION
Check if DNS_SERVER contains colons (IPv6) and wrap in brackets for nginx