### PR TITLE
Add configurable REMOTEIP_HEADER environment variable for Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ These variables are common to image variants and will set defaults based on the 
 | PROXY_SSL_CA_CERT_FILE  | A string indicating the path to the PEM-encoded list of accepted CA certificates for the proxied server (Default: `/etc/ssl/certs/ca-certificates.crt`) |
 | PROXY_SSL_CHECK_PEER_NAME  | A string indicating if the host name checking for remote server certificates is to be enabled (Default: `on`) |
 | REMOTEIP_INT_PROXY  | A string indicating the client intranet IP addresses trusted to present the RemoteIPHeader value (Default: `10.1.0.0/16`) |
+| REMOTEIP_HEADER   | A string indicating the header to use for RemoteIPHeader value (Default: `X-Forwarded-For`)  |
 | REQ_HEADER_FORWARDED_PROTO  | A string indicating the transfer protocol of the initial request (Default: `https`) |
 | SERVER_ADMIN  | A string value indicating the address where problems with the server should be e-mailed (Default: `root@localhost`) |
 | SERVER_SIGNATURE | A string value configuring the footer on server-generated documents (Allowed values: `On`, `Off`, `EMail`. Default: `Off`) |

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -134,6 +134,7 @@ ENV \
     PROXY_SSL_VERIFY=none \
     PROXY_TIMEOUT=60 \
     REMOTEIP_INT_PROXY='10.1.0.0/16' \
+    REMOTEIP_HEADER='X-Forwarded-For' \
     REQ_HEADER_FORWARDED_PROTO='https' \
     SERVER_ADMIN=root@localhost \
     SERVER_NAME=localhost \

--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -144,6 +144,7 @@ ENV \
     PROXY_SSL_VERIFY=none \
     PROXY_TIMEOUT=60 \
     REMOTEIP_INT_PROXY='10.1.0.0/16' \
+    REMOTEIP_HEADER='X-Forwarded-For' \
     REQ_HEADER_FORWARDED_PROTO='https' \
     SERVER_ADMIN=root@localhost \
     SERVER_NAME=localhost \

--- a/apache/conf/extra/httpd-vhosts.conf
+++ b/apache/conf/extra/httpd-vhosts.conf
@@ -9,7 +9,7 @@ ProxyPreserveHost ${PROXY_PRESERVE_HOST}
 ProxyRequests off
 ProxyTimeout ${PROXY_TIMEOUT}
 
-RemoteIPHeader X-Forwarded-For
+RemoteIPHeader ${REMOTEIP_HEADER}
 RemoteIPInternalProxy ${REMOTEIP_INT_PROXY}
 
 RequestHeader set X-Forwarded-Proto "${REQ_HEADER_FORWARDED_PROTO}"


### PR DESCRIPTION
- Add REMOTEIP_HEADER environment variable with X-Forwarded-For default
- Replace hardcoded RemoteIPHeader with ${REMOTEIP_HEADER} variable
- Update both regular and Alpine Dockerfiles
- Add documentation to README.md
- Maintains backward compatibility while allowing custom headers
- Enables CloudFront setups to use alternative header sources, such as CloudFront-Viewer-Address , vastly simplifying maintaining trusted ip lists