### PR TITLE
ci(publish): add key for matrix.target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,12 +73,12 @@ jobs:
           provenance: true
           sbom: true
 
-      - name: Sign the images with GitHub OIDC Token
+      - name: 'Sign the image for ${{ matrix.target }} with GitHub OIDC Token'
         env:
           METADATA: ${{ steps.build-and-push.outputs.metadata }}
         run: |
-          DIGEST=$(echo ${METADATA} | jq -r '.[] | ."containerimage.digest"')
-          TAGS=$(echo ${METADATA} | jq -r '.[] | ."image.name" | tostring' | tr ',' '\n')
+          DIGEST=$(echo ${METADATA} | jq -r '."${{ matrix.target }}" ."containerimage.digest"')
+          TAGS=$(echo ${METADATA} | jq -r '."${{ matrix.target }}" ."image.name" | tostring' | tr ',' '\n')
           images=""
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "


### PR DESCRIPTION
## what

- add key to index proper container image metadata

## why

- fix release

## tests

Using this sampled json output, from one of the failed builds (notice the added `buildx.build.warnings`):
```json
{
  "apache-alpine-3-3-7": {
    "buildx.build.ref": "builder-b9bbe4fa-025e-4bb2-8c9a-8d657e3e0312/builder-b9bbe4fa-025e-4bb2-8c9a-8d657e3e03120/325v4oju7bmxtxjrfxkl584vd",
    "containerimage.descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:90884c176e54d5333a1b8ce11d07b77c5742ac9df0ede39af737c6cee2608306",
      "size": 3136
    },
    "containerimage.digest": "sha256:90884c176e54d5333a1b8ce11d07b77c5742ac9df0ede39af737c6cee2608306",
    "image.name": "owasp"
  },
  "buildx.build.warnings": [
    {
      "vertex": "1"
    }
  ]
}
```
We get:
```sh
cat sample.json| jq -r '."apache-alpine-3-3-7" ."containerimage.digest"'
sha256:90884c176e54d5333a1b8ce11d07b77c5742ac9df0ede39af737c6cee2608306
```
and
```sh
cat sample.json| jq -r '."apache-alpine-3-3-7" ."image.name"'
owasp
```