### PR TITLE
fix: drop support for 32-bit ARM (arm/v7)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -121,7 +121,7 @@ group "default" {
 
 target "platforms-base" {
     context="."
-    platforms = ["linux/amd64", "linux/arm64/v8", "linux/arm/v7", "linux/i386"]
+    platforms = ["linux/amd64", "linux/arm64", "linux/i386"]
     labels = {
         "org.opencontainers.image.source" = "https://github.com/coreruleset/modsecurity-crs-docker"
     }


### PR DESCRIPTION
Certain packages are no longer available for 32-bit ARM, libcurl3-gnutls for Debian specifically.

We choose to drop support for 32-bit ARM instead of investing time to find a workaround.