### PR TITLE
feat: Nginx configurable X-Forwarded-Proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ These variables are common to image variants and will set defaults based on the 
 | HTTP2 | A string value indicating whether HTTP/2 should be enabled (for all locations) (Allowed values: `on`, `off`. Default: `on`) |
 | KEEPALIVE_TIMEOUT  | Number of seconds for a keep-alive client connection to stay open on the server side (Default: `60s`) |
 | NGINX_ALWAYS_TLS_REDIRECT | A string value indicating if http should redirect to https (Allowed values: `on`, `off`. Default: `off`) |
+| NGINX_X_FORWARDED_PROTO | A string indicating the transfer protocol of the initial request (Default: `$scheme`) |
 | PORT | An int value indicating the port where the webserver is listening to | `8080` | We run as unprivileged user. |
 | PROXY_SSL_VERIFY_DEPTH  | An integer value indicating the verification depth for the client certificate chain (Default: `1`) |
 | REAL_IP_HEADER | Name of the header containing the real IP value(s) (Default: `X-REAL-IP`). See [real_ip_header](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header) |

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -183,6 +183,7 @@ ENV \
     MODSEC_UPLOAD_KEEP_FILES=Off \
     NGINX_ALWAYS_TLS_REDIRECT=off \
     NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
+    NGINX_X_FORWARDED_PROTO='$scheme' \
     PORT=8080 \
     PROXY_SSL_CERT_FILE=/etc/nginx/conf/proxy.crt \
     PROXY_SSL_CERT_KEY_FILE=/etc/nginx/conf/proxy.key \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -184,6 +184,7 @@ ENV \
     MODSEC_UPLOAD_KEEP_FILES=Off \
     NGINX_ALWAYS_TLS_REDIRECT=off \
     NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
+    NGINX_X_FORWARDED_PROTO='$scheme' \
     PORT=8080 \
     PROXY_SSL_CERT_FILE=/etc/nginx/conf/proxy.crt \
     PROXY_SSL_CERT_KEY_FILE=/etc/nginx/conf/proxy.key \

--- a/nginx/templates/includes/proxy_backend.conf.template
+++ b/nginx/templates/includes/proxy_backend.conf.template
@@ -5,7 +5,7 @@ proxy_set_header Connection $connection_upgrade;
 proxy_set_header ${REAL_IP_PROXY_HEADER} $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Port $server_port;
-proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Proto ${NGINX_X_FORWARDED_PROTO};
 
 proxy_http_version 1.1;
 proxy_buffering off;


### PR DESCRIPTION
Make `X-Forwarded-Proto` configurable for proxy chain scenario with only `https` on first/initial proxy.