### PR TITLE
Fix: add missing ErrorLogFormat

### DIFF
--- a/apache/conf/extra/httpd-modsecurity.conf
+++ b/apache/conf/extra/httpd-modsecurity.conf
@@ -14,6 +14,7 @@ SecServerSignature ${MODSEC_SERVER_SIGNATURE}
 # The "common" and "combined" formats are predefined
 LogFormat ${APACHE_LOGFORMAT} modsec
 LogFormat ${APACHE_METRICS_LOGFORMAT} metricslog
+ErrorLogFormat ${APACHE_ERRORLOG_FORMAT}
 
 CustomLog ${METRICSLOG} metricslog "env=!nologging"
 


### PR DESCRIPTION
This PR adds the missing `ErrorLogFormat` directive to Apache. It's on the README but was not configured somewhere in the container.