### PR TITLE
feat: add LTS-specific build tags for v3 and v4 CRS releases

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -92,9 +92,9 @@ jobs:
 
       - name: Run ${{ matrix.target }}
         run: |
-          # get the major version from the matrix.target 
-          # The targets end with `<major>-<minor>-<patch>`.
-          CRS_VERSION="v$(awk -F'-' '{print $(NF-2)}' <<< ${{ matrix.target }})"
+          # get the major CRS version from the matrix.target
+          # Targets ending with "previous" are v3; all others are v4.
+          CRS_VERSION="$([[ "${{ matrix.target }}" == *-previous ]] && echo v3 || echo v4)"
           . .github/workflows/configure-rules-for-test.sh \
             "src/opt/modsecurity/configure-rules.${CRS_VERSION}.conf" \
             README.md \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Examples:
    * `nginx`
    * `apache-alpine`
 
+### LTS Tags
+
+LTS (Long-Term Support) tags are stable tags pointing to a designated LTS release. They are updated less frequently than stable tags and are intended for users who prioritize stability over new features.
+
+LTS Tags are composed of:
+   * CRS version, in the format `<minor>` or `<minor>.<patch>`
+   * web server variant
+   * OS variant (optional)
+   * `lts` suffix
+
+The LTS tag format is `<CRS version>-<web server>[-<os>]-lts`.
+Examples:
+   * `4.25-nginx-lts`
+   * `4.25.0-nginx-lts`
+   * `4.25-apache-lts`
+   * `4.25.0-apache-alpine-lts`
+
 ## OS Variants
 
 * nginx – *latest stable ModSecurity v3 on Nginx 1.28.2 official stable base image, and latest stable OWASP CRS 4.25.0*

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,7 +18,7 @@ variable "modsec2-flags" {
 }
 
 variable "v3-lts-crs-version" {
-    default = "3.3.8"
+    default = "3.3.9"
 }
 
 variable "major-crs-version" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,11 +31,11 @@ variable "v4-lts-crs-version" {
 }
 
 variable "crs-versions" {
-  default = {
-    "previous" = v3-lts-crs-version,
-    "lts" = v4-lts-crs-version,
-    "latest" = major-crs-version
-  }
+  default = [
+    { tag = "previous", version = v3-lts-crs-version },
+    { tag = "lts",      version = v4-lts-crs-version },
+    { tag = "latest",   version = major-crs-version }
+  ]
 }
 
 variable "nginx-version" {
@@ -150,7 +150,7 @@ target "platforms-base" {
 
 target "apache" {
     matrix = {
-        crs_release = crs-versions
+        crs_entry = crs-versions
         base = [
             {
                 name = "debian"
@@ -170,25 +170,25 @@ target "apache" {
     }
 
     inherits = ["platforms-base"]
-    name = "apache-${base.name}-${replace(crs_release, ".", "-")}"
+    name = "apache-${base.name}-${crs_entry.tag}"
     contexts = {
         image = base.image
     }
     dockerfile = base.dockerfile
     args = {
-        CRS_RELEASE = "${crs_release}"
+        CRS_RELEASE = crs_entry.version
         LUA_MODULES = base.lua_modules
     }
     tags = concat(
         tag(base.tag_base),
-        vtag("${crs_release}", base.tag_base),
-        equal(crs_release, v4-lts-crs-version) ? lts-tag("${crs_release}", base.tag_base) : []
+        vtag("${crs_entry.version}", base.tag_base),
+        equal(crs_entry.tag, "lts") ? lts-tag("${crs_entry.version}", base.tag_base) : []
     )
 }
 
 target "nginx" {
     matrix = {
-        crs_release = crs-versions
+        crs_entry = crs-versions
         base = [
             {
                 name = "debian"
@@ -218,13 +218,13 @@ target "nginx" {
         ]
     }
     inherits = ["platforms-base"]
-    name = "nginx-${base.name}-${read-only-fs.name}-${replace(crs_release, ".", "-")}"
+    name = "nginx-${base.name}-${read-only-fs.name}-${crs_entry.tag}"
     contexts = {
         image = base.image
     }
     dockerfile = base.dockerfile
     args = {
-        CRS_RELEASE = crs_release
+        CRS_RELEASE = crs_entry.version
         NGINX_VERSION = nginx-version
         LUA_MODULES = base.lua_modules
         NGINX_DYNAMIC_MODULES = join(" ", [for mod in nginx-dynamic-modules : join(" ", [mod.owner, mod.name, mod.version])])
@@ -233,7 +233,7 @@ target "nginx" {
     }
     tags = concat(
         tag("${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
-        vtag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
-        equal(crs_release, v4-lts-crs-version) ? lts-tag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}") : []
+        vtag("${crs_entry.version}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
+        equal(crs_entry.tag, "lts") ? lts-tag("${crs_entry.version}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}") : []
     )
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,7 +32,7 @@ variable "v4-lts-crs-version" {
 
 variable "crs-versions" {
   default = [
-    { tag = "previous-lts", version = v3-lts-crs-version },
+    { tag = "previous-lts", version = previous-lts-crs-version },
     { tag = "lts",      version = v4-lts-crs-version },
     { tag = "latest",   version = major-crs-version }
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,6 +33,7 @@ variable "v4-lts-crs-version" {
 variable "crs-versions" {
   default = {
     "previous" = v3-lts-crs-version,
+    "lts" = v4-lts-crs-version,
     "latest" = major-crs-version
   }
 }
@@ -116,7 +117,7 @@ function "vtag" {
     )
 }
 
-function "ltag" {
+function "lts-tag" {
     params = [semver, variant]
     result = concat(
         tag("${minor(semver)}-${variant}-lts"),
@@ -181,7 +182,7 @@ target "apache" {
     tags = concat(
         tag(base.tag_base),
         vtag("${crs_release}", base.tag_base),
-        equal(crs_release, v4-lts-crs-version) ? ltag("${crs_release}", base.tag_base) : []
+        equal(crs_release, v4-lts-crs-version) ? lts-tag("${crs_release}", base.tag_base) : []
     )
 }
 
@@ -233,6 +234,6 @@ target "nginx" {
     tags = concat(
         tag("${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
         vtag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
-        equal(crs_release, v4-lts-crs-version) ? ltag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}") : []
+        equal(crs_release, v4-lts-crs-version) ? lts-tag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}") : []
     )
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "modsec2-flags" {
     default = "--with-yajl --with-ssdeep --with-pcre2"
 }
 
-variable "v3-lts-crs-version" {
+variable "previous-lts-crs-version" {
     default = "3.3.9"
 }
 
@@ -32,7 +32,7 @@ variable "v4-lts-crs-version" {
 
 variable "crs-versions" {
   default = [
-    { tag = "previous", version = v3-lts-crs-version },
+    { tag = "previous-lts", version = v3-lts-crs-version },
     { tag = "lts",      version = v4-lts-crs-version },
     { tag = "latest",   version = major-crs-version }
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "modsec2-flags" {
     default = "--with-yajl --with-ssdeep --with-pcre2"
 }
 
-variable "previous-major-crs-version" {
+variable "v3-lts-crs-version" {
     default = "3.3.8"
 }
 
@@ -26,9 +26,13 @@ variable "major-crs-version" {
     default = "4.25.0"
 }
 
+variable "v4-lts-crs-version" {
+    default = "4.25.0"
+}
+
 variable "crs-versions" {
-  default = { 
-    "previous" = previous-major-crs-version,
+  default = {
+    "previous" = v3-lts-crs-version,
     "latest" = major-crs-version
   }
 }
@@ -112,6 +116,14 @@ function "vtag" {
     )
 }
 
+function "ltag" {
+    params = [semver, variant]
+    result = concat(
+        tag("${minor(semver)}-${variant}-lts"),
+        tag("${patch(semver)}-${variant}-lts")
+    )
+}
+
 group "default" {
     targets = [
         "apache",
@@ -166,8 +178,10 @@ target "apache" {
         CRS_RELEASE = "${crs_release}"
         LUA_MODULES = base.lua_modules
     }
-    tags = concat(tag(base.tag_base),
-        vtag("${crs_release}", base.tag_base)
+    tags = concat(
+        tag(base.tag_base),
+        vtag("${crs_release}", base.tag_base),
+        equal(crs_release, v4-lts-crs-version) ? ltag("${crs_release}", base.tag_base) : []
     )
 }
 
@@ -216,7 +230,9 @@ target "nginx" {
         NGINX_HOME = "/etc/nginx"
         READ_ONLY_FS = read-only-fs.read-only
     }
-    tags = concat(tag("${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
-        vtag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}")
+    tags = concat(
+        tag("${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
+        vtag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}"),
+        equal(crs_release, v4-lts-crs-version) ? ltag("${crs_release}", "${base.tag_base}${equal(read-only-fs.read-only, "true") ? "-read-only" : ""}") : []
     )
 }


### PR DESCRIPTION
## Summary

- Introduces `v3-lts-crs-version` and `v4-lts-crs-version` variables (renaming the old `previous-major-crs-version`) to track LTS releases independently from the monthly `major-crs-version` updates
- `v3-lts-crs-version` is set to `3.3.9`, `v4-lts-crs-version` is set to `4.25.0`
- Adds a new `ltag` HCL function that generates stable `<minor>-<variant>-lts` and `<patch>-<variant>-lts` tags (no timestamp), applied only when the build target matches the designated LTS version
- Documents the new LTS tag format in `README.md`

## Test plan

- [x] Verify `docker buildx bake --print` shows the expected LTS tags (e.g. `4.25-nginx-lts`, `4.25.0-apache-lts`) on the `major-crs-version` targets
- [x] Verify LTS tags are **not** present on the `v3-lts-crs-version` (3.3.9) targets
- [x] Verify existing stable and rolling tags are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)