### PR TITLE
fix: patch msc_find_lib.m4 for multiarch library detection

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -51,8 +51,7 @@ RUN set -eux; \
     git clone https://github.com/owasp-modsecurity/ModSecurity --branch "v${MODSEC3_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
     ARCH=$(gcc -print-multiarch); \
-    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/ssdeep.m4; \
-    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/pcre2.m4; \
+    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/msc_find_lib.m4; \
     ./build.sh; \
     ./configure ${MODSEC3_FLAGS}; \
     make -j$(nproc) install; \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -48,8 +48,7 @@ RUN set -eux; \
     git clone https://github.com/owasp-modsecurity/ModSecurity --branch "v${MODSEC3_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
     ARCH=$(gcc -print-multiarch); \
-    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/ssdeep.m4; \
-    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/pcre2.m4; \
+    sed -ie "s/i386-linux-gnu/${ARCH}/g" build/msc_find_lib.m4; \
     ./build.sh; \
     ./configure ${MODSEC3_FLAGS}; \
     make -j$(nproc) install; \


### PR DESCRIPTION
ModSecurity v3.0.15 refactored library detection to centralize hardcoded architecture paths in build/msc_find_lib.m4. The ssdeep.m4 and pcre2.m4 files are now thin wrappers that delegate to MSC_CHECK_LIB.

Patch only msc_find_lib.m4 to replace 'i386-linux-gnu' with the actual detected architecture. This fixes SSDEEP library detection on arm64 and other non-x86 platforms.

Fixes build failures on linux/arm64 and linux/i386 with ModSecurity v3.0.15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ModSecurity build configuration in Docker images (standard and Alpine variants) to refine multi-architecture support during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coreruleset/modsecurity-crs-docker/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->