### PR TITLE
Patching nginx manuallz because the default 7days of renovate take too long for this security fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Examples:
 
 ## OS Variants
 
-* nginx – *latest stable ModSecurity v3 on Nginx 1.30.0 official stable base image, and latest stable OWASP CRS 4.26.0*
+* nginx – *latest stable ModSecurity v3 on Nginx 1.31.0 official stable base image, and latest stable OWASP CRS 4.26.0*
    * [nginx](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)
    * [nginx-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine)
 * Apache httpd – *last stable ModSecurity v2 on Apache 2.4.67 official stable base image, and latest stable OWASP CRS 4.26.0*

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -40,7 +40,7 @@ variable "crs-versions" {
 
 variable "nginx-version" {
     # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
-    default = "1.30.0"
+    default = "1.31.0"
 }
 
 variable "httpd-version" {


### PR DESCRIPTION
Signed-off-by: Tim Beermann <tibeer@berryit.de>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded nginx version to 1.31.0 in the Docker build configuration and updated documentation accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coreruleset/modsecurity-crs-docker/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->