### PR TITLE
docs: Fix inaccurate LTS tags format description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Examples:
 LTS (Long-Term Support) tags are stable tags pointing to a designated LTS release. They are updated less frequently than stable tags and are intended for users who prioritize stability over new features.
 
 LTS Tags are composed of:
-   * CRS version, in the format `<minor>` or `<minor>.<patch>`
+   * CRS version, in the format `<major>.<minor>` or `<major>.<minor>.<patch>`
    * web server variant
    * OS variant (optional)
    * `lts` suffix


### PR DESCRIPTION
This pull request fixes the issue where the description of the LTS tags format does not match the actual image tag names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LTS tag composition description to support additional CRS version format variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->