### PR TITLE
Update httpd to 2.4.68

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Examples:
 * nginx – *latest stable ModSecurity v3 on Nginx 1.30.1 official stable base image, and latest stable OWASP CRS 4.27.0*
    * [nginx](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile)
    * [nginx-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/nginx/Dockerfile-alpine)
-* Apache httpd – *last stable ModSecurity v2 on Apache 2.4.67 official stable base image, and latest stable OWASP CRS 4.27.0*
+* Apache httpd – *last stable ModSecurity v2 on Apache 2.4.68 official stable base image, and latest stable OWASP CRS 4.27.0*
    * [apache](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile)
    * [apache-alpine](https://github.com/coreruleset/modsecurity-crs-docker/blob/master/apache/Dockerfile-alpine)
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -45,7 +45,7 @@ variable "nginx-version" {
 
 variable "httpd-version" {
     # renovate: depName=httpd datasource=docker
-    default = "2.4.67"
+    default = "2.4.68"
 }
 
 variable "modsecurity-nginx-version" {


### PR DESCRIPTION
The upstream Docker image was updated to 2.4.68 on June 8: https://github.com/docker-library/httpd/commit/4da43810a4429c552e19c43f8e513248c34cfc84. This release addresses several CVEs: https://downloads.apache.org/httpd/CHANGES_2.4.68

It's unclear to me why Renovate hasn't pulled this update in yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Apache httpd version from 2.4.67 to 2.4.68.
  * Refreshed documentation to reflect the new httpd/ModSecurity base image used for supported OS variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->