### PR TITLE
chore: exempt upstream base images from renovate cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,13 +47,27 @@
       "matchDepNames": [
         "ModSecurity2"
       ],
-      "allowedVersions": "/^v2.*/"
+      "allowedVersions": "/^v2.*/",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDepNames": [
+        "ModSecurity3"
+      ],
+      "minimumReleaseAge": "0 days"
     },
     {
       "matchDepNames": [
         "nginxinc/nginx-unprivileged"
       ],
-      "allowedVersions": "/^[0-9]+\\.(?:[1-9]\\d*)?[02468]\\.[0-9]+$/"
+      "allowedVersions": "/^[0-9]+\\.(?:[1-9]\\d*)?[02468]\\.[0-9]+$/",
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDepNames": [
+        "httpd"
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: "0 days"` package rules for `ModSecurity2`, `ModSecurity3`, `httpd`, and `nginxinc/nginx-unprivileged` in `renovate.json`
- These upstream base images/binaries should be updated as soon as released, unlike other dependencies which go through a cooldown as a security measure

## Test plan
- [ ] Renovate config validated as valid JSON
- [ ] Confirm Renovate picks up the new package rules on the next scheduled run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update rules to allow certain packages to be updated immediately after release.
  * Expanded existing rules for several server-related dependencies while keeping current version limits where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->