### PR TITLE
fix: don't split image build by target platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,10 @@ jobs:
         uses: docker/bake-action/subaction/matrix@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
           target: default
-          fields: platforms
 
   build:
     name: Build ${{ matrix.target }}
-    runs-on: ${{ startsWith(matrix.platforms, 'linux/arm') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs:
       - prepare
     permissions:
@@ -76,8 +75,6 @@ jobs:
           files: |
             ./docker-bake.hcl
           targets: ${{ matrix.target }}
-          set: |
-            *.platform=${{ matrix.platforms }}
           push: true
           provenance: true
           sbom: true


### PR DESCRIPTION
As discussed in #443, 7c1554f introduced parallelized image builds across bake targets **and** platforms (previously it was just by bake targets). This introduced an error where multiple image for the same target (i.e., tag) but with different platforms were built and pushed concurrently and only the final push remained on Docker Hub/GHCR, so each tag had only one platform available.

Fixing this in the current setup would require pushing individual digests first and then tagging them at the end by manually building a manifest, as [docker/github-builder](https://github.com/docker/github-builder/blob/2ed0b42d4b91658ed511ca56581527d0af1f958d/.github/workflows/bake.yml#L1173) does. This is likely difficult to support as it is complex and requires duplicating image names to the GitHub CI setup.

I tried setting up the docker/github-builder action for this repository but it conflicts with the extensive tag setup in the Bakefile (the action requires meta-images for each additional tag).

I thus simply reverted the changes to .github/workflows/publish.yml (.github/workflows/verifyimage.yml works correctly as far as I can see from [this job](https://github.com/coreruleset/modsecurity-crs-docker/actions/runs/28405722161)). Unfortunately the CI pipeline is now much slower (as it was before 7c1554f) because of cross-platform builds and no parallelization.