### PR TITLE
fix: remove comment from bake-action set input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,6 +104,9 @@ jobs:
           repo="$(jq -r --arg t "${TARGET}" '.target[$t].tags[0] | split(":")[0]' bake-metadata.json)"
           echo "repo=${repo}" >> "${GITHUB_OUTPUT}"
 
+      # tags= clears the target's tags so this per-platform build doesn't push them; we tag
+      # everything at the end in the merge job, once all architectures have been built, to
+      # avoid a race condition where only the last-built platform would keep the tag
       - name: 'Build and push ${{ matrix.target }} (${{ matrix.platform }}) by digest'
         id: build-and-push
         uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # docker/bake-action@v6.9.0
@@ -113,8 +116,6 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             ${{ matrix.target }}.platform=${{ matrix.platform }}
-            # don't push tags; we do that at the end when all architectures have been built to
-            # avoid a race condition, where only the last built image would be tagged
             ${{ matrix.target }}.tags=
             ${{ matrix.target }}.output=type=image,name=${{ steps.repo.outputs.repo }},push-by-digest=true,name-canonical=true,push=true
           provenance: true


### PR DESCRIPTION
## Summary

Fixes the failure in [release/20260705](https://github.com/coreruleset/modsecurity-crs-docker/actions/runs/28749252355), the first release run after #447 merged.

`docker/bake-action`'s `set` input is a plain newline-separated list of `target.key=value` overrides, not YAML — each line is passed straight to `docker buildx bake --set`. The explanatory comment added during #447's review (a `#`-prefixed line inside the `set: |` block) isn't a comment to `bake --set`, it's an invalid override key, and it broke every one of the 36 build jobs identically:

```
cannot parse bake definitions: ERROR: invalid override key # don't push tags; we do that at the end when all architectures have been built to, expected target.name
```

Moved the explanation to a real YAML comment above the step (outside the block scalar), where it can't be fed into `bake --set`.

## Validation

- Reproduced the exact error locally: `docker buildx bake --print ... --set "# don't push tags..."` throws the identical `invalid override key` error.
- Confirmed the fix: same command without the comment line resolves cleanly.
- `actionlint` and `zizmor` pass clean.

## Test plan

- [ ] Merge and trigger a real release; confirm all 36 build jobs and 12 merge jobs succeed and images publish correctly

## AI Disclosure

Per the project's [AI-Assisted Contribution Policy](https://github.com/coreruleset/coreruleset/blob/main/AI-CONTRIBUTIONS.md):

1. **AI tools used**: Claude (Sonnet 5, via Claude Code)
2. **What was generated or assisted**: Root-cause analysis of the release/20260705 failure from the linked Actions run log, and the fix (moving the explanatory comment out of the `bake-action` `set` block scalar).
3. **Review performed**: Reproduced the exact `invalid override key` error locally against the real `docker-bake.hcl` before writing the fix, then confirmed the corrected `set` block resolves cleanly with the same local reproduction. `actionlint` and `zizmor` both pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build-and-push release process notes to better explain how tags are handled during platform-specific builds and later applied safely.
  * Improved inline guidance around the release workflow without changing build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
