### PR TITLE
fix: retry manifest push on GHCR rate limit, cap merge concurrency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,6 +154,10 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
     strategy:
+      # cap concurrent merge jobs so they don't collectively burst past GHCR's
+      # manifest-push rate limit (all 12 targets pushing at once has triggered
+      # 429 Too Many Requests on ghcr.io)
+      max-parallel: 4
       matrix:
         target: ${{ fromJson(needs.prepare.outputs.targets) }}
     steps:
@@ -207,7 +211,18 @@ jobs:
             sources+=("${repo}@sha256:$(basename "$digest_file")")
           done
 
-          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          max_attempts=5
+          attempt=1
+          until docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"; do
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "imagetools create failed after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+            sleep_seconds=$((attempt * 5))
+            echo "imagetools create failed (attempt ${attempt}/${max_attempts}); retrying in ${sleep_seconds}s" >&2
+            sleep "${sleep_seconds}"
+            attempt=$((attempt + 1))
+          done
           digest=$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest}}' | jq -r '.digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Fixes the failure in [release/20260705's second run](https://github.com/coreruleset/modsecurity-crs-docker/actions/runs/28752717908), after #448 fixed the earlier `bake --set` parse error.

All 36 build jobs succeeded this time, but all 12 `merge` jobs failed identically at `docker buildx imagetools create`:

```
ERROR: publish sha256:... to ghcr.io/coreruleset/modsecurity-crs:...: failed commit on ref "index-sha256:...": unexpected status from PUT request to https://ghcr.io/v2/coreruleset/modsecurity-crs/manifests/...: 429 Too Many Requests
toomanyrequests: retry-after: 12.5ms, allowed: 2000/minute
```

All 12 merge jobs (one per target) fire simultaneously and collectively burst past GHCR's short-window rate limit on manifest pushes. The `retry-after` values GHCR reported were all under 25ms, meaning this is a brief burst limit, not sustained throttling — a short wait should clear it.

## Fix

- `strategy.max-parallel: 4` on the `merge` job, so at most 4 targets push manifests concurrently instead of all 12 at once
- Retry `docker buildx imagetools create` up to 5 times with linear backoff (5s, 10s, 15s, 20s) on failure

## Validation

- Verified the retry loop logic in isolation (a fake command failing twice then succeeding is correctly retried and returns success)
- `actionlint` and `zizmor` pass clean

## Test plan

- [ ] Merge and trigger a real release; confirm all 12 merge jobs succeed without hitting GHCR rate limits


## AI Disclosure

Per the project's [AI-Assisted Contribution Policy](https://github.com/coreruleset/coreruleset/blob/main/AI-CONTRIBUTIONS.md):

1. **AI tools used**: Claude (Sonnet 5, via Claude Code)
2. **What was generated or assisted**: Root-cause analysis of the release/20260705 second-run failure from the linked Actions run log (confirmed identical 429 across all 12 merge jobs before diagnosing), and the fix (retry loop with backoff plus `max-parallel` cap).
3. **Review performed**: Verified the retry loop's control flow in an isolated shell test (fake failing command, confirmed correct retry/exit behavior) before adding it to the workflow. `actionlint` and `zizmor` both pass clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of release publishing by reducing parallel manifest updates.
  * Added automatic retries when creating multi-platform image manifests, with short waits between attempts to handle temporary failures more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->