### PR TITLE
fix: use a target-unique tag to read back the manifest digest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,12 @@ jobs:
         run: |
           set -euo pipefail
           repo=$(jq -r --arg t "$TARGET" '.target[$t].tags[0] | split(":")[0]' bake-metadata.json)
-          first_tag=$(jq -r --arg t "$TARGET" '.target[$t].tags[0]' bake-metadata.json)
+          # tags[0] is a floating tag (e.g. "nginx") shared by the latest/lts/previous-lts
+          # variants of the same target, so inspecting it after the push is racy: a sibling
+          # merge job can overwrite it before we read it back, and we'd sign the wrong
+          # digest. The last tag always embeds the exact CRS version, which differs across
+          # variants, so it's unique to this target.
+          unique_tag=$(jq -r --arg t "$TARGET" '.target[$t].tags[-1]' bake-metadata.json)
 
           tag_args=()
           while IFS= read -r tag; do
@@ -223,7 +228,7 @@ jobs:
             sleep "${sleep_seconds}"
             attempt=$((attempt + 1))
           done
-          digest=$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest}}' | jq -r '.digest')
+          digest=$(docker buildx imagetools inspect "$unique_tag" --format '{{json .Manifest}}' | jq -r '.digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: 'Sign the manifest for ${{ matrix.target }} with GitHub OIDC Token'


### PR DESCRIPTION
## Summary

Fixes the failure in [release/20260705's third run](https://github.com/coreruleset/modsecurity-crs-docker/actions/runs/28756020775), where 9 of 12 merge jobs succeeded but the 3 `nginx-debian-writable-*` jobs failed at the sign step:

```
Error: signing [...]: signing digest: HEAD https://ghcr.io/v2/coreruleset/modsecurity-crs/manifests/sha256:...: unexpected status code 404 Not Found
```

## Root cause

`docker-bake.hcl` gives a target's *floating* tag (e.g. `nginx`, shared by that web-server+base combo's `latest`/`lts`/`previous-lts` variants) as `tags[0]`. The merge job pushed its manifest, then called `docker buildx imagetools inspect "$first_tag"` (`tags[0]`) to read back the digest for signing.

Since `nginx-debian-writable-latest`, `-lts`, and `-previous-lts` all share that same floating tag, and their merge jobs ran concurrently, one job's push overwrote the shared tag before another job's `inspect` call ran — so that job read back a **different target's digest**, then tried to sign it. In one case the digest it read back had already become unreachable (no tag pointed to it anymore), hence the 404.

Confirmed from the run logs: `nginx-debian-writable-latest` pushed digest `07ff1c6f...`, but its own sign step's `DIGEST` env showed `7cfd9b236...` — the digest `nginx-debian-writable-previous-lts` had pushed to the same shared tag moments later.

## Fix

Read back the digest from the target's **last** tag instead of the first. The last tag always embeds the exact CRS patch version (plus an `-lts` suffix for the lts variant), which differs across variants and is therefore unique per target — verified this holds for all 12 real targets before making the change.

## Validation

- Confirmed via `docker buildx bake --print` that `tags[-1]` is unique across all 12 targets (no duplicates)
- `actionlint` and `zizmor` pass clean

## Test plan

- [ ] Merge and trigger a real release; confirm all 12 merge jobs succeed, including sign, and each signed digest matches what that target actually pushed

## AI Disclosure

Per the project's [AI-Assisted Contribution Policy](https://github.com/coreruleset/coreruleset/blob/main/AI-CONTRIBUTIONS.md):

1. **AI tools used**: Claude (Sonnet 5, via Claude Code)
2. **What was generated or assisted**: Root-cause analysis of the sign-step failure by cross-referencing the three nginx-debian merge jobs' logs (confirmed the shared-tag overwrite by timestamp/digest comparison), and the fix (switching the digest-readback reference to a target-unique tag).
3. **Review performed**: Verified `tags[-1]` uniqueness across all 12 real bake targets via `docker buildx bake --print` before writing the fix (not just reasoned about). `actionlint` and `zizmor` both pass clean.