### PR TITLE
ci: run the CRS tests with a single nginx worker

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -259,6 +259,14 @@ jobs:
         run: |
           yq e -i '(.test_overrides[] | select(.rule_id == 920100 and .test_ids[0] == 4 and (.test_ids | length) == 1) | .output.status) = 405' \
             crs/tests/regression/nginx-overrides.yaml
+      - name: Pin the CRS test container to a single nginx worker
+        # go-ftw bounds the log output of a request with markers. Several workers
+        # flush their buffers independently, so lines interleave and tests such as
+        # 956100 fail at random (https://github.com/coreruleset/go-ftw/issues/473).
+        # This applies to the test setup only; the images still default to "auto".
+        run: |
+          yq e -i '.services.modsec3-nginx.environment.NGINX_WORKER_PROCESSES = "1"' \
+            crs/tests/docker-compose.yml
       - name: Run CRS tests for ${{ matrix.target }}
         # Log flushing isn't reliable enough for go-ftw (https://github.com/coreruleset/go-ftw/issues/473)
         if: ${{!contains(matrix.target, 'nginx-alpine')}}


### PR DESCRIPTION
Follow-up to #456, which added `NGINX_WORKER_PROCESSES` for exactly this purpose but left the test setup on the default.

go-ftw bounds the log output of a request with markers. Several nginx workers flush their buffers independently, so lines interleave and tests such as 956100-X fail at random — see https://github.com/coreruleset/go-ftw/issues/473.

The workflow now patches the CRS compose file, next to the two patches already there:

```yaml
yq e -i '.services.modsec3-nginx.environment.NGINX_WORKER_PROCESSES = "1"' \
  crs/tests/docker-compose.yml
```

This is scoped to the test container. The images keep defaulting to `auto`, so nothing changes for users.

Verified locally against the current `coreruleset/tests/docker-compose.yml`: after the patch `docker compose config` exits 0, resolves `NGINX_WORKER_PROCESSES: "1"`, and still merges the anchored environment (`LOGLEVEL: info`, `SERVERNAME: modsec3-nginx`) — yq rewrites the merge key as `!!merge <<:`, which compose accepts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CRS test setup to run the ModSecurity NGINX test container with a single worker process.
  * Verification images retain their default NGINX worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->