### PR TITLE
ci: make the go-ftw download survive a reset connection

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -255,9 +255,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd crs
-          ARCH="${{ startsWith(matrix.platforms, 'linux/arm') && 'arm64' || 'amd64' }}"
-          gh release download -R coreruleset/go-ftw "v${{ env.GO_FTW_VERSION }}" \
-            -p "ftw_${{ env.GO_FTW_VERSION }}_linux_${ARCH}.tar.gz" -O - | tar -xzvf - ftw
+          # ftw runs on the runner, so its architecture decides the asset. Asking the
+          # runner keeps this from drifting apart from the runs-on mapping, and an
+          # architecture with no release fails here rather than on the first exec.
+          case "$(uname -m)" in
+            x86_64) arch="amd64" ;;
+            aarch64 | arm64) arch="arm64" ;;
+            *) echo "No go-ftw release for runner architecture $(uname -m)" >&2; exit 1 ;;
+          esac
+          # The release CDN resets connections now and then. Download to a file so a
+          # truncated transfer fails here instead of reaching tar, and retry it.
+          archive="ftw_${GO_FTW_VERSION}_linux_${arch}.tar.gz"
+          for attempt in 1 2 3; do
+            if gh release download -R coreruleset/go-ftw "v${GO_FTW_VERSION}" \
+                 -p "${archive}" --clobber; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Giving up on ${archive} after ${attempt} attempts"
+              exit 1
+            fi
+            delay=$((attempt * 5))
+            echo "Download failed, retrying in ${delay} seconds"
+            sleep "${delay}"
+          done
+          tar -xzf "${archive}" ftw
+          rm "${archive}"
       - name: Patch CRS compose file to use verification image
         run: |
           sed -i \


### PR DESCRIPTION
A run failed on this, with nothing else wrong:

```
gh release download -R coreruleset/go-ftw "v2.4.0" -p "ftw_2.4.0_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
Get "https://release-assets.githubusercontent.com/.../ftw_2.4.0_linux_amd64.tar.gz":
  read tcp 10.1.0.220:38988->185.199.109.133:443: read: connection reset by peer
```

## Retry

The download writes to a file and retries three times with a growing delay (5s, 10s). Downloading to a file also means a truncated transfer fails at the download, not inside `tar`: in the piped form the step exits with `tar`'s status, so a partial stream that `tar` happens to accept would have passed silently.

## Architecture

It now comes from the runner:

```bash
case "$(uname -m)" in
  x86_64) arch="amd64" ;;
  aarch64 | arm64) arch="arm64" ;;
  *) echo "No go-ftw release for runner architecture $(uname -m)" >&2; exit 1 ;;
esac
```

The previous expression, `startsWith(matrix.platforms, 'linux/arm') && 'arm64' || 'amd64'`, was correct but duplicated the `runs-on` mapping. ftw runs on the runner rather than in the image, so the runner architecture is what decides the asset — a `linux/i386` target builds on an x86_64 runner and needs the amd64 release, which the old expression got right only because both conditions were written the same way. go-ftw publishes `linux_amd64` and `linux_arm64` only, so an unexpected architecture now fails with a message instead of downloading a binary that cannot exec.

## Verification

Ran the step body against a stub `gh` that fails a set number of times:

| failures | attempts | exit | result |
|---|---|---|---|
| 0 | 1 | 0 | `ftw` extracted, archive removed |
| 2 | 3 | 0 | `ftw` extracted after 5s and 10s waits |
| 3 | 3 | 1 | `Giving up on ftw_2.4.0_linux_amd64.tar.gz after 3 attempts`, no files left behind |

And checked the architecture mapping for `x86_64`, `aarch64`, `arm64`, plus `i686` and `riscv64` reaching the error branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved go-ftw installation across supported runner architectures by selecting the appropriate release automatically.
  * Added automatic download retries with increasing delays to improve reliability on temporary network failures.
  * Added clear failure messages for unsupported architectures and unsuccessful downloads.
  * Improved archive extraction during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->