### PR TITLE
fix(alpine): upgrade base image packages during the build

### DIFF
--- a/apache/Dockerfile-alpine
+++ b/apache/Dockerfile-alpine
@@ -181,7 +181,10 @@ COPY apache/docker-entrypoint.sh /
 
 RUN addgroup -S httpd && adduser -SH httpd httpd
 
+# The base image carries whatever package versions it was built with, so security
+# updates released since then are only picked up by upgrading here.
 RUN set -eux; \
+    apk upgrade --no-cache; \
     apk add --no-cache \
         ca-certificates \
         curl \

--- a/nginx/Dockerfile-alpine
+++ b/nginx/Dockerfile-alpine
@@ -240,7 +240,10 @@ COPY src/bin/* /usr/local/bin/
 
 USER root
 
+# The base image carries whatever package versions it was built with, so security
+# updates released since then are only picked up by upgrading here.
 RUN set -eux; \
+    apk upgrade --no-cache; \
     apk add --no-cache \
         curl \
         curl-dev \


### PR DESCRIPTION
The Trivy gate in #459 caught this: the apache-alpine images carry three HIGH vulnerabilities that come from the base image, not from anything this repository installs.

`httpd:2.4.68-alpine` ships package versions frozen at its own build time, and `apk add` leaves them alone because they are already installed:

| package | in the base | fixed in Alpine | |
|---|---|---|---|
| `apr-util`, `apr-util-ldap` | 1.6.3-r2 | 1.6.4-r0 | CVE-2026-34191 |
| `c-ares` | 1.34.6-r0 | 1.34.8-r0 | CVE-2026-33630 |
| `libexpat` | 2.8.1-r0 | 2.8.2-r0 | CVE-2026-56408 |

An `apk upgrade --no-cache` in the runtime stage picks up whatever the distribution has released since. `nginx/Dockerfile-alpine` gets the same line: its base only lags on `apk-tools` today, but it drifts the same way, and the two images should not differ in this.

## Verification

Built both images locally for linux/arm64 and scanned them with the flags the gate uses:

| image | fixable HIGH+CRITICAL before | after |
|---|---|---|
| `apache-alpine` | 4 | 0 |
| `nginx-alpine` | 0 | 0 |

The upgraded versions are in the image (`apr-util-1.6.4-r0`, `apr-util-ldap-1.6.4-r0`, `c-ares-1.34.8-r0`, `libexpat-2.8.2-r0`), and both containers still block a path traversal request with 403 — apache through mod_security2 2.9.14, nginx through libmodsecurity 3.0.16 with 850 rules loaded.

Merging this before #459 keeps that gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Alpine-based runtime images to upgrade installed system packages during image creation.
  - Added documentation clarifying the security update behavior of the base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->